### PR TITLE
Add Docker Nightly CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,9 +18,3 @@ jobs:
 
       - name: Format with prettier
         run: npx prettier --check '**/*'
-
-      - name: Format markdown with prettier
-        run: npx prettier --prose-wrap always --check '**/*.md'
-
-      - name: Format YAML with prettier
-        run: npx prettier --prose-wrap always --check '**/*.{yaml,yml}'

--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -1,0 +1,42 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [master, test]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        image: [ubuntu, debian-slim]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Get current date
+        id: timestamp
+        run: echo "::set-output name=datetime::$(date -u +'%Y%m%d%H%M%S')"
+
+      - name: Build the Docker image
+        run: >-
+          docker build .
+          --build-arg ARTICHOKE_NIGHTLY_VER=${{ steps.timestamp.outputs.datetime }}
+          --file Dockerfile.${{ matrix.image }}
+          --tag artichokerb/artichoke:${{ matrix.image }}-nightly-github-${{ github.run_id }}-${{ github.run_number }}
+          --tag artichokerb/artichoke:${{ matrix.image }}-nightly-${{ steps.timestamp.outputs.datetime }}
+          --tag artichokerb/artichoke:${{ matrix.image }}-nightly
+
+      - name: Tag canonical image as latest
+        if: matrix.image == 'ubuntu'
+        run: >-
+          docker tag artichokerb/artichoke:${{ matrix.image }}-nightly artichokerb/artichoke:latest
+
+      - name: Push the Docker image
+        env:
+          DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          docker login -u "$DOCKERHUB_USER" -p "$DOCKERHUB_TOKEN"
+          docker push artichokerb/artichoke

--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        image: [ubuntu, debian-slim]
+        image: [ubuntu, debian-slim, alpine]
 
     steps:
       - uses: actions/checkout@v2

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,9 @@
+overrides:
+  # Always wrap markdown
+  - files: "*.md"
+    options:
+      proseWrap: always
+  # Preserve wrap for yaml as wrapping make some commands less readable
+  - files: "*.{yaml,yml}"
+    options:
+      proseWrap: preserve

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,78 @@
+FROM ubuntu:18.04 AS build
+
+RUN apt-get update \
+    && apt-get install -y libssl-dev \
+    llvm-dev clang libclang-dev \
+    wget git cmake build-essential pkg-config
+
+# Rust setup
+ARG RUST_VERSION=1.43.0
+
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH
+
+RUN set -eux; \
+    dpkgArch="$(dpkg --print-architecture)"; \
+    case "${dpkgArch##*-}" in \
+        amd64) rustArch='x86_64-unknown-linux-gnu'; rustupSha256='ad1f8b5199b3b9e231472ed7aa08d2e5d1d539198a15c5b1e53c746aad81d27b' ;; \
+        armhf) rustArch='armv7-unknown-linux-gnueabihf'; rustupSha256='6c6c3789dabf12171c7f500e06d21d8004b5318a5083df8b0b02c0e5ef1d017b' ;; \
+        arm64) rustArch='aarch64-unknown-linux-gnu'; rustupSha256='26942c80234bac34b3c1352abbd9187d3e23b43dae3cf56a9f9c1ea8ee53076d' ;; \
+        i386) rustArch='i686-unknown-linux-gnu'; rustupSha256='27ae12bc294a34e566579deba3e066245d09b8871dc021ef45fc715dced05297' ;; \
+        *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
+    esac; \
+    url="https://static.rust-lang.org/rustup/archive/1.21.1/${rustArch}/rustup-init"; \
+    wget "$url"; \
+    echo "${rustupSha256} *rustup-init" | sha256sum -c -; \
+    chmod +x rustup-init; \
+    ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION; \
+    rm rustup-init; \
+    chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
+    rustup --version; \
+    cargo --version; \
+    rustc --version;
+
+# Add libmusl support for Alpine
+RUN set -eux; \
+    rustup target add x86_64-unknown-linux-musl
+
+# Ruby setup
+ARG RUBY_VERSION=2.6.3
+ARG RUBY_INSTALL_VERSION=0.7.0
+ARG RUBY_INSTALL_SHA=500a8ac84b8f65455958a02bcefd1ed4bfcaeaa2bb97b8f31e61ded5cd0fd70b
+
+RUN set -eux; \
+    echo 'gem: --no-document' >> /usr/local/etc/gemrc; \
+    url="https://github.com/postmodern/ruby-install/archive/v$RUBY_INSTALL_VERSION.tar.gz"; \
+    wget -O /tmp/ruby-install.tar.gz "$url"; \
+    echo "${RUBY_INSTALL_SHA} /tmp/ruby-install.tar.gz" | sha256sum -c -; \
+    tar -xzvf /tmp/ruby-install.tar.gz -C /opt && rm /tmp/ruby-install.tar.gz; \
+    /opt/ruby-install-$RUBY_INSTALL_VERSION/bin/ruby-install -i /usr/local/ ruby $RUBY_VERSION -- --disable-install-rdoc; \
+    rm /usr/local/src/ruby-$RUBY_VERSION.tar.bz2; \
+    gem update --system; \
+    ruby --version; \
+    gem --version; \
+    bundle --version;
+
+# XXX HACK - the following build arg is used primarily to break caching and force rebuild, since
+# we're bulding nightlies here and fetching something like HEAD commit SHA will complicate things
+ARG ARTICHOKE_NIGHTLY_VER=latest
+# Intall musl-gcc for alpine taget
+RUN apt-get install -y musl-tools
+# Install artichoke
+RUN set -eux; \
+    cargo install --git https://github.com/artichoke/artichoke --locked artichoke \
+    --target x86_64-unknown-linux-musl; \
+    airb --version; \
+    artichoke --version;
+
+# Setup runtime
+FROM alpine:3 AS runtime
+
+COPY --from=build /usr/local/cargo/bin/artichoke /opt/artichoke/bin/artichoke
+COPY --from=build /usr/local/cargo/bin/airb /opt/artichoke/bin/airb
+
+ENV ARTICHOKE_BIN /opt/artichoke/bin
+ENV PATH $ARTICHOKE_BIN:$PATH
+
+CMD [ "airb" ]

--- a/Dockerfile.debian-slim
+++ b/Dockerfile.debian-slim
@@ -1,0 +1,71 @@
+FROM debian:10-slim AS build
+
+RUN apt-get update \
+    && apt-get install -y libssl-dev \
+    llvm-dev clang libclang-dev \
+    wget git cmake build-essential pkg-config
+
+# Rust setup
+ARG RUST_VERSION=1.43.0
+
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH
+
+RUN set -eux; \
+    dpkgArch="$(dpkg --print-architecture)"; \
+    case "${dpkgArch##*-}" in \
+        amd64) rustArch='x86_64-unknown-linux-gnu'; rustupSha256='ad1f8b5199b3b9e231472ed7aa08d2e5d1d539198a15c5b1e53c746aad81d27b' ;; \
+        armhf) rustArch='armv7-unknown-linux-gnueabihf'; rustupSha256='6c6c3789dabf12171c7f500e06d21d8004b5318a5083df8b0b02c0e5ef1d017b' ;; \
+        arm64) rustArch='aarch64-unknown-linux-gnu'; rustupSha256='26942c80234bac34b3c1352abbd9187d3e23b43dae3cf56a9f9c1ea8ee53076d' ;; \
+        i386) rustArch='i686-unknown-linux-gnu'; rustupSha256='27ae12bc294a34e566579deba3e066245d09b8871dc021ef45fc715dced05297' ;; \
+        *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
+    esac; \
+    url="https://static.rust-lang.org/rustup/archive/1.21.1/${rustArch}/rustup-init"; \
+    wget "$url"; \
+    echo "${rustupSha256} *rustup-init" | sha256sum -c -; \
+    chmod +x rustup-init; \
+    ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION; \
+    rm rustup-init; \
+    chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
+    rustup --version; \
+    cargo --version; \
+    rustc --version;
+
+# Ruby setup
+ARG RUBY_VERSION=2.6.3
+ARG RUBY_INSTALL_VERSION=0.7.0
+ARG RUBY_INSTALL_SHA=500a8ac84b8f65455958a02bcefd1ed4bfcaeaa2bb97b8f31e61ded5cd0fd70b
+
+RUN set -eux; \
+    echo 'gem: --no-document' >> /usr/local/etc/gemrc; \
+    url="https://github.com/postmodern/ruby-install/archive/v$RUBY_INSTALL_VERSION.tar.gz"; \
+    wget -O /tmp/ruby-install.tar.gz "$url"; \
+    echo "${RUBY_INSTALL_SHA} /tmp/ruby-install.tar.gz" | sha256sum -c -; \
+    tar -xzvf /tmp/ruby-install.tar.gz -C /opt && rm /tmp/ruby-install.tar.gz; \
+    /opt/ruby-install-$RUBY_INSTALL_VERSION/bin/ruby-install -i /usr/local/ ruby $RUBY_VERSION -- --disable-install-rdoc; \
+    rm /usr/local/src/ruby-$RUBY_VERSION.tar.bz2; \
+    gem update --system; \
+    ruby --version; \
+    gem --version; \
+    bundle --version;
+
+# XXX HACK - the following build arg is used primarily to break caching and force rebuild, since
+# we're bulding nightlies here and fetching something like HEAD commit SHA will complicate things
+ARG ARTICHOKE_NIGHTLY_VER=latest
+# Install artichoke
+RUN set -eux; \
+    cargo install --git https://github.com/artichoke/artichoke --locked artichoke; \
+    airb --version; \
+    artichoke --version;
+
+# Setup runtime
+FROM debian:10-slim AS runtime
+
+COPY --from=build /usr/local/cargo/bin/artichoke /opt/artichoke/bin/artichoke
+COPY --from=build /usr/local/cargo/bin/airb /opt/artichoke/bin/airb
+
+ENV ARTICHOKE_BIN /opt/artichoke/bin
+ENV PATH $ARTICHOKE_BIN:$PATH
+
+CMD [ "airb" ]

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,0 +1,71 @@
+FROM ubuntu:18.04 AS build
+
+RUN apt-get update \
+    && apt-get install -y libssl-dev \
+    llvm-dev clang libclang-dev \
+    wget git cmake build-essential pkg-config
+
+# Rust setup
+ARG RUST_VERSION=1.43.0
+
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH
+
+RUN set -eux; \
+    dpkgArch="$(dpkg --print-architecture)"; \
+    case "${dpkgArch##*-}" in \
+        amd64) rustArch='x86_64-unknown-linux-gnu'; rustupSha256='ad1f8b5199b3b9e231472ed7aa08d2e5d1d539198a15c5b1e53c746aad81d27b' ;; \
+        armhf) rustArch='armv7-unknown-linux-gnueabihf'; rustupSha256='6c6c3789dabf12171c7f500e06d21d8004b5318a5083df8b0b02c0e5ef1d017b' ;; \
+        arm64) rustArch='aarch64-unknown-linux-gnu'; rustupSha256='26942c80234bac34b3c1352abbd9187d3e23b43dae3cf56a9f9c1ea8ee53076d' ;; \
+        i386) rustArch='i686-unknown-linux-gnu'; rustupSha256='27ae12bc294a34e566579deba3e066245d09b8871dc021ef45fc715dced05297' ;; \
+        *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
+    esac; \
+    url="https://static.rust-lang.org/rustup/archive/1.21.1/${rustArch}/rustup-init"; \
+    wget "$url"; \
+    echo "${rustupSha256} *rustup-init" | sha256sum -c -; \
+    chmod +x rustup-init; \
+    ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION; \
+    rm rustup-init; \
+    chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
+    rustup --version; \
+    cargo --version; \
+    rustc --version;
+
+# Ruby setup
+ARG RUBY_VERSION=2.6.3
+ARG RUBY_INSTALL_VERSION=0.7.0
+ARG RUBY_INSTALL_SHA=500a8ac84b8f65455958a02bcefd1ed4bfcaeaa2bb97b8f31e61ded5cd0fd70b
+
+RUN set -eux; \
+    echo 'gem: --no-document' >> /usr/local/etc/gemrc; \
+    url="https://github.com/postmodern/ruby-install/archive/v$RUBY_INSTALL_VERSION.tar.gz"; \
+    wget -O /tmp/ruby-install.tar.gz "$url"; \
+    echo "${RUBY_INSTALL_SHA} /tmp/ruby-install.tar.gz" | sha256sum -c -; \
+    tar -xzvf /tmp/ruby-install.tar.gz -C /opt && rm /tmp/ruby-install.tar.gz; \
+    /opt/ruby-install-$RUBY_INSTALL_VERSION/bin/ruby-install -i /usr/local/ ruby $RUBY_VERSION -- --disable-install-rdoc; \
+    rm /usr/local/src/ruby-$RUBY_VERSION.tar.bz2; \
+    gem update --system; \
+    ruby --version; \
+    gem --version; \
+    bundle --version;
+
+# XXX HACK - the following build arg is used primarily to break caching and force rebuild, since
+# we're bulding nightlies here and fetching something like HEAD commit SHA will complicate things
+ARG ARTICHOKE_NIGHTLY_VER=latest
+# Install artichoke
+RUN set -eux; \
+    cargo install --git https://github.com/artichoke/artichoke --locked artichoke; \
+    airb --version; \
+    artichoke --version;
+
+# Setup runtime
+FROM ubuntu:18.04 AS runtime
+
+COPY --from=build /usr/local/cargo/bin/artichoke /opt/artichoke/bin/artichoke
+COPY --from=build /usr/local/cargo/bin/airb /opt/artichoke/bin/airb
+
+ENV ARTICHOKE_BIN /opt/artichoke/bin
+ENV PATH $ARTICHOKE_BIN:$PATH
+
+CMD [ "airb" ]

--- a/README.md
+++ b/README.md
@@ -24,16 +24,27 @@ For the workflow to work 2 secrets need to be setup in repository settings:
 
 ## Docker-nightly
 
+### Platforms
+
+Currently supported docker platforms are:
+
+- `ubuntu` - canonical mainline image, tagged with `-ubuntu` and `latest`
+- `debian-slim` - Debian 10 (Buster) slim image
+- `alpine` - Alpine 3 image
+
 ### Secrets
 
-- `secrets.DOCKERHUB_USER` - DockerHub username that the workflow will use to push the image
-- `secrets.DOCKERHUB_TOKEN` - DockerHub user token that the workflow will authorise with
+- `secrets.DOCKERHUB_USER` - DockerHub username that the workflow will use to
+  push the image
+- `secrets.DOCKERHUB_TOKEN` - DockerHub user token that the workflow will
+  authorise with
 
 ### Build Args
 
 - `RUST_VERSION` - Rust toolchain version
 - `RUBY_VERSION` - Version of the ruby interpreter to build
 - `RUBY_INSTALL_VERSION` - Version of the `ruby-install` tool to use
-- `RUBY_INSTALL_SHA` - SHA256 of the `ruby-install` package (e.g. `openssl dgst -sha256 PACKAGE`)
-- `ARTICHOKE_NIGHTLY_VER` - Argument used for cache invalidation (see `Dockerfile`), defaults to
-  `date -u +'%Y%m%d%H%M%S'`.
+- `RUBY_INSTALL_SHA` - SHA256 of the `ruby-install` package (e.g.
+  `openssl dgst -sha256 PACKAGE`)
+- `ARTICHOKE_NIGHTLY_VER` - Argument used for cache invalidation (see
+  `Dockerfile`), defaults to `date -u +'%Y%m%d%H%M%S'`.

--- a/README.md
+++ b/README.md
@@ -6,3 +6,34 @@
 
 Docker images for nightly builds of
 [Artichoke Ruby](https://github.com/artichoke/artichoke).
+
+Pull and run the latest image:
+
+```
+$ docker run -it docker.io/artichokerb/artichoke airb
+```
+
+## Quickstart
+
+For the workflow to work 2 secrets need to be setup in repository settings:
+
+- `secrets.DOCKERHUB_USER`
+- `secrets.DOCKERHUB_TOKEN`
+
+# Workflows
+
+## Docker-nightly
+
+### Secrets
+
+- `secrets.DOCKERHUB_USER` - DockerHub username that the workflow will use to push the image
+- `secrets.DOCKERHUB_TOKEN` - DockerHub user token that the workflow will authorise with
+
+### Build Args
+
+- `RUST_VERSION` - Rust toolchain version
+- `RUBY_VERSION` - Version of the ruby interpreter to build
+- `RUBY_INSTALL_VERSION` - Version of the `ruby-install` tool to use
+- `RUBY_INSTALL_SHA` - SHA256 of the `ruby-install` package (e.g. `openssl dgst -sha256 PACKAGE`)
+- `ARTICHOKE_NIGHTLY_VER` - Argument used for cache invalidation (see `Dockerfile`), defaults to
+  `date -u +'%Y%m%d%H%M%S'`.


### PR DESCRIPTION
For now the platforms supported are:
- Ubuntu
- Debian-slim (Buster/10)
- Alpine

@lopopolo - PTAL, some questions:
- Where do you want me to publish images? 
   I created https://hub.docker.com/orgs/artichokerb If that works - is it ok to give me access to set secrets in the repo? I'll add a bot account so we don't have to use personal tokens. Otherwise - just plug in the secrets according to `README.md` so this starts working.