### PR TITLE
Followups to GH-3

### DIFF
--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -1,8 +1,13 @@
 name: Docker Image CI
-
 on:
   push:
-    branches: [master, test]
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  schedule:
+    - cron: "0 0 * * *" # build nightly!
 
 jobs:
   build:
@@ -10,33 +15,47 @@ jobs:
 
     strategy:
       matrix:
-        image: [ubuntu, debian-slim, alpine]
+        image: [ubuntu, slim, alpine]
 
     steps:
       - uses: actions/checkout@v2
 
-      - name: Get current date
-        id: timestamp
-        run: echo "::set-output name=datetime::$(date -u +'%Y%m%d%H%M%S')"
+      - name: Get Artichoke HEAD commit
+        id: master_commit
+        run: |
+          MASTER_COMMIT_SHA="$(curl https://api.github.com/repos/artichoke/artichoke/commits/master | jq '.sha')"
+          echo "::set-output name=sha::$MASTER_COMMIT_SHA"
 
       - name: Build the Docker image
         run: >-
           docker build .
-          --build-arg ARTICHOKE_NIGHTLY_VER=${{ steps.timestamp.outputs.datetime }}
+          --build-arg ARTICHOKE_NIGHTLY_VER=${{ steps.master_commit.outputs.sha }}
           --file Dockerfile.${{ matrix.image }}
-          --tag artichokerb/artichoke:${{ matrix.image }}-nightly-github-${{ github.run_id }}-${{ github.run_number }}
-          --tag artichokerb/artichoke:${{ matrix.image }}-nightly-${{ steps.timestamp.outputs.datetime }}
-          --tag artichokerb/artichoke:${{ matrix.image }}-nightly
+          --tag artichokeruby/artichoke:${{ matrix.image }}-nightly
+          --tag artichokeruby/artichoke:${{ matrix.image }}-nightly-${{ steps.master_commit.outputs.sha }}
 
-      - name: Tag canonical image as latest
+      - name: Extra Canonical image tags
         if: matrix.image == 'ubuntu'
-        run: >-
-          docker tag artichokerb/artichoke:${{ matrix.image }}-nightly artichokerb/artichoke:latest
+        run: |
+          docker tag artichokeruby/artichoke:${{ matrix.image }}-nightly artichokeruby/artichoke:latest
+          docker tag artichokeruby/artichoke:${{ matrix.image }}-nightly artichokeruby/artichoke:${{ steps.master_commit.outputs.sha }}
+          docker tag artichokeruby/artichoke:${{ matrix.image }}-nightly artichokeruby/artichoke:${{ matrix.image }}18.04-nightly
+
+      - name: Extra Debian image tags
+        if: matrix.image == 'slim'
+        run: |
+          docker tag artichokeruby/artichoke:${{ matrix.image }}-nightly artichokerb/artichoke:${{ matrix.image }}-buster-nightly
+
+      - name: Extra Alpine image tags
+        if: matrix.image == 'alpine'
+        run: |
+          docker tag artichokeruby/artichoke:${{ matrix.image }}-nightly artichokerb/artichoke:${{ matrix.image }}3-nightly
 
       - name: Push the Docker image
+        if: github.ref == 'refs/heads/master'
         env:
           DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
           docker login -u "$DOCKERHUB_USER" -p "$DOCKERHUB_TOKEN"
-          docker push artichokerb/artichoke
+          docker push artichokeruby/artichoke

--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Get Artichoke HEAD commit
         id: master_commit
         run: |
-          MASTER_COMMIT_SHA="$(curl https://api.github.com/repos/artichoke/artichoke/commits/master | jq '.sha')"
+          MASTER_COMMIT_SHA="$(curl https://api.github.com/repos/artichoke/artichoke/commits/master | jq --raw-output '.sha')"
           echo "::set-output name=sha::$MASTER_COMMIT_SHA"
 
       - name: Build the Docker image

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -54,8 +54,10 @@ RUN set -eux; \
     gem --version; \
     bundle --version;
 
-# XXX HACK - the following build arg is used primarily to break caching and force rebuild, since
-# we're bulding nightlies here and fetching something like HEAD commit SHA will complicate things
+# XXX HACK - The `ARTICHOKE_NIGHTLY_VER` build arg is unused, but can be set at
+# build time to break layer caching and force a rebuild of Artichoke from latest
+# master. The GitHub Actions workflow sets this to the latest master commit SHA
+# in the upstream Artichoke repository.
 ARG ARTICHOKE_NIGHTLY_VER=latest
 # Intall musl-gcc for alpine taget
 RUN apt-get install -y musl-tools

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -1,4 +1,4 @@
-FROM debian:10-slim AS build
+FROM debian:buster-slim AS build
 
 RUN apt-get update \
     && apt-get install -y libssl-dev \
@@ -50,8 +50,10 @@ RUN set -eux; \
     gem --version; \
     bundle --version;
 
-# XXX HACK - the following build arg is used primarily to break caching and force rebuild, since
-# we're bulding nightlies here and fetching something like HEAD commit SHA will complicate things
+# XXX HACK - The `ARTICHOKE_NIGHTLY_VER` build arg is unused, but can be set at
+# build time to break layer caching and force a rebuild of Artichoke from latest
+# master. The GitHub Actions workflow sets this to the latest master commit SHA
+# in the upstream Artichoke repository.
 ARG ARTICHOKE_NIGHTLY_VER=latest
 # Install artichoke
 RUN set -eux; \
@@ -60,7 +62,7 @@ RUN set -eux; \
     artichoke --version;
 
 # Setup runtime
-FROM debian:10-slim AS runtime
+FROM debian:buster-slim AS runtime
 
 COPY --from=build /usr/local/cargo/bin/artichoke /opt/artichoke/bin/artichoke
 COPY --from=build /usr/local/cargo/bin/airb /opt/artichoke/bin/airb

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -50,8 +50,10 @@ RUN set -eux; \
     gem --version; \
     bundle --version;
 
-# XXX HACK - the following build arg is used primarily to break caching and force rebuild, since
-# we're bulding nightlies here and fetching something like HEAD commit SHA will complicate things
+# XXX HACK - The `ARTICHOKE_NIGHTLY_VER` build arg is unused, but can be set at
+# build time to break layer caching and force a rebuild of Artichoke from latest
+# master. The GitHub Actions workflow sets this to the latest master commit SHA
+# in the upstream Artichoke repository.
 ARG ARTICHOKE_NIGHTLY_VER=latest
 # Install artichoke
 RUN set -eux; \

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Docker images for nightly builds of
 
 Pull and run the latest image:
 
-```
-$ docker run -it docker.io/artichokerb/artichoke airb
+```console
+$ docker run -it docker.io/artichokeruby/artichoke airb
 ```
 
 ## Quickstart
@@ -22,15 +22,17 @@ For the workflow to work 2 secrets need to be setup in repository settings:
 
 # Workflows
 
-## Docker-nightly
+## docker-nightly
 
 ### Platforms
 
 Currently supported docker platforms are:
 
-- `ubuntu` - canonical mainline image, tagged with `-ubuntu` and `latest`
-- `debian-slim` - Debian 10 (Buster) slim image
-- `alpine` - Alpine 3 image
+- `ubuntu` - canonical mainline image, tagged with `latest`, `ubuntu-nightly`,
+  and `ubuntu18.04-nightly`.
+- `debian-slim` - Debian 10 (Buster) slim image, tagged `slim-nightly` and
+  `slim-buster-nightly`.
+- `alpine` - Alpine 3 image, tagged with `alpine-nightly` and `alpine3-nightly`.
 
 ### Secrets
 
@@ -47,4 +49,5 @@ Currently supported docker platforms are:
 - `RUBY_INSTALL_SHA` - SHA256 of the `ruby-install` package (e.g.
   `openssl dgst -sha256 PACKAGE`)
 - `ARTICHOKE_NIGHTLY_VER` - Argument used for cache invalidation (see
-  `Dockerfile`), defaults to `date -u +'%Y%m%d%H%M%S'`.
+  `Dockerfile`), defaults to SHA of latest master commit in upstream Artichoke
+  repository.


### PR DESCRIPTION
Followups to GH-3 to productionize the build.

External to this PR I created an artichokeruby Docker Hub organization
and an artichokeci machine user.

- Update GitHub Actions workflow schedule to build nightly + on PRs and
  master merges.
- Fetch latest master branch SHA from Artichoke repository to use as the
  ARTICHOKE_NIGHTLY_VER build arg.
- Tag every image as '{{ image }}-nightly' and '{{ image }}-nightly-{{ sha }}'.
- Tag ubuntu image as 'latest' and '{{ sha }}'
- Add tags for all images to specifiy the tag used in the base image
- Rename debian base image from 10-slim tag to buster-slim