### PR TITLE
Transition the main branch to be 'trunk'

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,10 +2,10 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - trunk
   pull_request:
     branches:
-      - master
+      - trunk
   schedule:
     - cron: "0 0 * * TUE"
 jobs:

--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -21,28 +21,33 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Get Artichoke HEAD commit
-        id: trunk
-        run: |
-          COMMIT_SHA="$(curl https://api.github.com/repos/artichoke/artichoke/commits/master | jq --raw-output '.sha')"
-          echo "::set-output name=sha::$COMMIT_SHA"
+      - name: Clone Artichoke
+        uses: actions/checkout@v2
+        with:
+          repository: artichoke/artichoke
+          path: artichoke
+
+      - name: Set Artichoke latest commit
+        id: latest
+        working-directory: artichoke
+        run: echo "::set-output name=commit::$(git rev-parse HEAD)"
 
       - name: Build the Docker image
         run: >-
           docker build .
-          --build-arg ARTICHOKE_NIGHTLY_VER=${{ steps.trunk.outputs.sha }}
+          --build-arg ARTICHOKE_NIGHTLY_VER=${{ steps.latest.outputs.commit }}
           --file Dockerfile.${{ matrix.image }}
           --tag artichokeruby/artichoke:${{ matrix.image }}-nightly
-          --tag artichokeruby/artichoke:${{ matrix.image }}-nightly-${{ steps.trunk.outputs.sha }}
+          --tag artichokeruby/artichoke:${{ matrix.image }}-nightly-${{ steps.latest.outputs.commit }}
           --label "org.opencontainers.image.created=$(date --rfc-3339=seconds)"
-          --label "org.opencontainers.image.version=${{ steps.trunk.outputs.sha }}"
-          --label "org.opencontainers.image.revision=${{ steps.trunk.outputs.sha }}"
+          --label "org.opencontainers.image.version=${{ steps.latest.outputs.commit }}"
+          --label "org.opencontainers.image.revision=${{ steps.latest.outputs.commit }}"
 
       - name: Extra Canonical image tags
         if: matrix.image == 'ubuntu'
         run: |
           docker tag artichokeruby/artichoke:${{ matrix.image }}-nightly artichokeruby/artichoke:latest
-          docker tag artichokeruby/artichoke:${{ matrix.image }}-nightly artichokeruby/artichoke:${{ steps.trunk.outputs.sha }}
+          docker tag artichokeruby/artichoke:${{ matrix.image }}-nightly artichokeruby/artichoke:${{ steps.latest.outputs.commit }}
           docker tag artichokeruby/artichoke:${{ matrix.image }}-nightly artichokeruby/artichoke:${{ matrix.image }}18.04-nightly
 
       - name: Extra Debian image tags

--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -2,10 +2,10 @@ name: Docker Image CI
 on:
   push:
     branches:
-      - master
+      - trunk
   pull_request:
     branches:
-      - master
+      - trunk
   schedule:
     - cron: "0 0 * * *" # build nightly!
 
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         image: [ubuntu, slim, alpine]
 
@@ -21,27 +22,27 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Get Artichoke HEAD commit
-        id: master_commit
+        id: trunk
         run: |
-          MASTER_COMMIT_SHA="$(curl https://api.github.com/repos/artichoke/artichoke/commits/master | jq --raw-output '.sha')"
-          echo "::set-output name=sha::$MASTER_COMMIT_SHA"
+          COMMIT_SHA="$(curl https://api.github.com/repos/artichoke/artichoke/commits/master | jq --raw-output '.sha')"
+          echo "::set-output name=sha::$COMMIT_SHA"
 
       - name: Build the Docker image
         run: >-
           docker build .
-          --build-arg ARTICHOKE_NIGHTLY_VER=${{ steps.master_commit.outputs.sha }}
+          --build-arg ARTICHOKE_NIGHTLY_VER=${{ steps.trunk.outputs.sha }}
           --file Dockerfile.${{ matrix.image }}
           --tag artichokeruby/artichoke:${{ matrix.image }}-nightly
-          --tag artichokeruby/artichoke:${{ matrix.image }}-nightly-${{ steps.master_commit.outputs.sha }}
+          --tag artichokeruby/artichoke:${{ matrix.image }}-nightly-${{ steps.trunk.outputs.sha }}
           --label "org.opencontainers.image.created=$(date --rfc-3339=seconds)"
-          --label "org.opencontainers.image.version=${{ steps.master_commit.outputs.sha }}"
-          --label "org.opencontainers.image.revision=${{ steps.master_commit.outputs.sha }}"
+          --label "org.opencontainers.image.version=${{ steps.trunk.outputs.sha }}"
+          --label "org.opencontainers.image.revision=${{ steps.trunk.outputs.sha }}"
 
       - name: Extra Canonical image tags
         if: matrix.image == 'ubuntu'
         run: |
           docker tag artichokeruby/artichoke:${{ matrix.image }}-nightly artichokeruby/artichoke:latest
-          docker tag artichokeruby/artichoke:${{ matrix.image }}-nightly artichokeruby/artichoke:${{ steps.master_commit.outputs.sha }}
+          docker tag artichokeruby/artichoke:${{ matrix.image }}-nightly artichokeruby/artichoke:${{ steps.trunk.outputs.sha }}
           docker tag artichokeruby/artichoke:${{ matrix.image }}-nightly artichokeruby/artichoke:${{ matrix.image }}18.04-nightly
 
       - name: Extra Debian image tags
@@ -55,7 +56,7 @@ jobs:
           docker tag artichokeruby/artichoke:${{ matrix.image }}-nightly artichokerb/artichoke:${{ matrix.image }}3-nightly
 
       - name: Push the Docker image
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/trunk'
         env:
           DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/repo-labels.yaml
+++ b/.github/workflows/repo-labels.yaml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - master
+      - trunk
     paths:
       - .github/labels.json
 name: Create Repository Labels

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -56,8 +56,8 @@ RUN set -eux; \
 
 # XXX HACK - The `ARTICHOKE_NIGHTLY_VER` build arg is unused, but can be set at
 # build time to break layer caching and force a rebuild of Artichoke from latest
-# master. The GitHub Actions workflow sets this to the latest master commit SHA
-# in the upstream Artichoke repository.
+# trunk. The GitHub Actions workflow sets this to the latest trunk commit SHA in
+# the upstream Artichoke repository.
 ARG ARTICHOKE_NIGHTLY_VER=latest
 # Intall musl-gcc for alpine taget
 RUN apt-get install -y musl-tools

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -52,8 +52,8 @@ RUN set -eux; \
 
 # XXX HACK - The `ARTICHOKE_NIGHTLY_VER` build arg is unused, but can be set at
 # build time to break layer caching and force a rebuild of Artichoke from latest
-# master. The GitHub Actions workflow sets this to the latest master commit SHA
-# in the upstream Artichoke repository.
+# trunk. The GitHub Actions workflow sets this to the latest trunk commit SHA in
+# the upstream Artichoke repository.
 ARG ARTICHOKE_NIGHTLY_VER=latest
 # Install artichoke
 RUN set -eux; \

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -52,8 +52,8 @@ RUN set -eux; \
 
 # XXX HACK - The `ARTICHOKE_NIGHTLY_VER` build arg is unused, but can be set at
 # build time to break layer caching and force a rebuild of Artichoke from latest
-# master. The GitHub Actions workflow sets this to the latest master commit SHA
-# in the upstream Artichoke repository.
+# trunk. The GitHub Actions workflow sets this to the latest trunk commit SHA in
+# the upstream Artichoke repository.
 ARG ARTICHOKE_NIGHTLY_VER=latest
 # Install artichoke
 RUN set -eux; \

--- a/README.md
+++ b/README.md
@@ -50,5 +50,5 @@ Currently supported docker platforms are:
 - `RUBY_INSTALL_SHA` - SHA256 of the `ruby-install` package (e.g.
   `openssl dgst -sha256 PACKAGE`)
 - `ARTICHOKE_NIGHTLY_VER` - Argument used for cache invalidation (see
-  `Dockerfile`), defaults to SHA of latest master commit in upstream Artichoke
+  `Dockerfile`), defaults to SHA of latest trunk commit in upstream Artichoke
   repository.


### PR DESCRIPTION
This matches other new Artichoke repositories like intaglio and
focaccia.

Add `fail-fast: false` to the build strategy for the docker builder.

Update HEAD commit fetching strategy to match `artichoke/nightly`.