### PR TITLE
 Set oci image source metadata to artichoke/artichoke

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -73,7 +73,7 @@ FROM alpine:3 AS runtime
 
 LABEL org.opencontainers.image.authors="Artem Yakimenko <http://temikus.net>, Ryan Lopopolo <rjl@hyperbo.la>"
 LABEL org.opencontainers.image.url="https://github.com/artichoke/docker-artichoke-nightly"
-LABEL org.opencontainers.image.source="https://github.com/artichoke/docker-artichoke-nightly"
+LABEL org.opencontainers.image.source="https://github.com/artichoke/artichoke"
 LABEL org.opencontainers.image.vendor="Artichoke Ruby <https://www.artichokeruby.org>"
 LABEL org.opencontainers.image.licenses="MIT"
 LABEL org.opencontainers.image.ref.name="nightly"

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -66,7 +66,7 @@ FROM debian:buster-slim AS runtime
 
 LABEL org.opencontainers.image.authors="Artem Yakimenko <http://temikus.net>, Ryan Lopopolo <rjl@hyperbo.la>"
 LABEL org.opencontainers.image.url="https://github.com/artichoke/docker-artichoke-nightly"
-LABEL org.opencontainers.image.source="https://github.com/artichoke/docker-artichoke-nightly"
+LABEL org.opencontainers.image.source="https://github.com/artichoke/artichoke"
 LABEL org.opencontainers.image.vendor="Artichoke Ruby <https://www.artichokeruby.org>"
 LABEL org.opencontainers.image.licenses="MIT"
 LABEL org.opencontainers.image.ref.name="nightly"

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -66,7 +66,7 @@ FROM ubuntu:18.04 AS runtime
 
 LABEL org.opencontainers.image.authors="Artem Yakimenko <http://temikus.net>, Ryan Lopopolo <rjl@hyperbo.la>"
 LABEL org.opencontainers.image.url="https://github.com/artichoke/docker-artichoke-nightly"
-LABEL org.opencontainers.image.source="https://github.com/artichoke/docker-artichoke-nightly"
+LABEL org.opencontainers.image.source="https://github.com/artichoke/artichoke"
 LABEL org.opencontainers.image.vendor="Artichoke Ruby <https://www.artichokeruby.org>"
 LABEL org.opencontainers.image.licenses="MIT"
 LABEL org.opencontainers.image.ref.name="nightly"


### PR DESCRIPTION
The commit revisions attached to the image come from artichoke/artichoke,
not artichoke/docker-artichoke-nightly.

image.url remains pointed to the artichoke/docker-artichoke-nightly repo.

Followup to GH-5.