### PR TITLE
Echo Artichoke git ref and Rust toolchain version in nightly CI

### DIFF
--- a/.github/workflows/docker-nightly.yaml
+++ b/.github/workflows/docker-nightly.yaml
@@ -27,12 +27,16 @@ jobs:
       - name: Set Artichoke latest commit
         id: latest
         working-directory: artichoke
-        run: echo "::set-output name=commit::$(git rev-parse HEAD)"
+        run: |
+          echo "Artichoke git ref: $(git rev-parse HEAD)"
+          echo "::set-output name=commit::$(git rev-parse HEAD)"
 
       - name: Set Artichoke Rust toolchain version
         id: rust_toolchain
         working-directory: artichoke
-        run: echo "::set-output name=version::$(cat rust-toolchain)"
+        run: |
+          echo "Rust toolchain version: $(cat rust-toolchain)"
+          echo "::set-output name=version::$(cat rust-toolchain)"
 
       - name: Login to DockerHub
         uses: docker/login-action@v1
@@ -71,12 +75,16 @@ jobs:
       - name: Set Artichoke latest commit
         id: latest
         working-directory: artichoke
-        run: echo "::set-output name=commit::$(git rev-parse HEAD)"
+        run: |
+          echo "Artichoke git ref: $(git rev-parse HEAD)"
+          echo "::set-output name=commit::$(git rev-parse HEAD)"
 
       - name: Set Artichoke Rust toolchain version
         id: rust_toolchain
         working-directory: artichoke
-        run: echo "::set-output name=version::$(cat rust-toolchain)"
+        run: |
+          echo "Rust toolchain version: $(cat rust-toolchain)"
+          echo "::set-output name=version::$(cat rust-toolchain)"
 
       - name: Login to DockerHub
         uses: docker/login-action@v1
@@ -113,12 +121,16 @@ jobs:
       - name: Set Artichoke latest commit
         id: latest
         working-directory: artichoke
-        run: echo "::set-output name=commit::$(git rev-parse HEAD)"
+        run: |
+          echo "Artichoke git ref: $(git rev-parse HEAD)"
+          echo "::set-output name=commit::$(git rev-parse HEAD)"
 
       - name: Set Artichoke Rust toolchain version
         id: rust_toolchain
         working-directory: artichoke
-        run: echo "::set-output name=version::$(cat rust-toolchain)"
+        run: |
+          echo "Rust toolchain version: $(cat rust-toolchain)"
+          echo "::set-output name=version::$(cat rust-toolchain)"
 
       - name: Login to DockerHub
         uses: docker/login-action@v1


### PR DESCRIPTION
This leaves logs in CI to track the provenance of the container images.