### PR TITLE
Use newline delimited list for image tags

### DIFF
--- a/.github/workflows/docker-nightly.yaml
+++ b/.github/workflows/docker-nightly.yaml
@@ -53,11 +53,11 @@ jobs:
           context: .
           file: ubuntu/bionic/Dockerfile
           push: ${{ github.ref == 'refs/heads/trunk' }}
-          tags: >
-            artichokeruby/artichoke:latest,
-            artichokeruby/artichoke:${{ steps.latest.outputs.commit }},
-            artichokeruby/artichoke:ubunutu-nightly,
-            artichokeruby/artichoke:ubuntu18.04-nightly,
+          tags: |
+            artichokeruby/artichoke:latest
+            artichokeruby/artichoke:${{ steps.latest.outputs.commit }}
+            artichokeruby/artichoke:ubunutu-nightly
+            artichokeruby/artichoke:ubuntu18.04-nightly
             artichokeruby/artichoke:ubuntu-nightly-${{ steps.latest.outputs.commit }}
           build-args: |
             ARTICHOKE_NIGHTLY_VER=${{ steps.latest.outputs.commit }}
@@ -105,9 +105,9 @@ jobs:
           context: .
           file: debian/buster/slim/Dockerfile
           push: ${{ github.ref == 'refs/heads/trunk' }}
-          tags: >
-            artichokeruby/artichoke:slim-nightly,
-            artichokeruby/artichoke:slim-buster-nightly,
+          tags: |
+            artichokeruby/artichoke:slim-nightly
+            artichokeruby/artichoke:slim-buster-nightly
             artichokeruby/artichoke:slim-nightly-${{ steps.latest.outputs.commit }}
           build-args: |
             ARTICHOKE_NIGHTLY_VER=${{ steps.latest.outputs.commit }}
@@ -155,9 +155,9 @@ jobs:
           context: .
           file: alpine/Dockerfile
           push: ${{ github.ref == 'refs/heads/trunk' }}
-          tags: >
-            artichokeruby/artichoke:alpine-nightly,
-            artichokeruby/artichoke:alpine3-nightly,
+          tags: |
+            artichokeruby/artichoke:alpine-nightly
+            artichokeruby/artichoke:alpine3-nightly
             artichokeruby/artichoke:alpine-nightly-${{ steps.latest.outputs.commit }}
           build-args: |
             ARTICHOKE_NIGHTLY_VER=${{ steps.latest.outputs.commit }}


### PR DESCRIPTION
An upstream change to the CSV parsing used by `docker/build-push-action`
caused the leading spaces in tag names to no longer be stripped.

This could be fixed by using the `>-` YAML multi-line string folder, but
`|` and a newline delimited list is clearer. This syntax matches what is
used by the `build-args` parameter to the `docker/build-push-action`
action.