### PR TITLE
Update cargo install instructions to declare 'trunk' branch

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -54,20 +54,23 @@ RUN set -eux; \
     gem --version; \
     bundle --version;
 
-# XXX HACK - The `ARTICHOKE_NIGHTLY_VER` build arg is unused, but can be set at
-# build time to break layer caching and force a rebuild of Artichoke from latest
-# trunk. The GitHub Actions workflow sets this to the latest trunk commit SHA in
-# the upstream Artichoke repository.
-ARG ARTICHOKE_NIGHTLY_VER=latest
 # Intall musl-gcc for alpine taget
 RUN apt-get install -y musl-tools
+
+# The `ARTICHOKE_NIGHTLY_VER` build arg allows building a specific revision of
+# Artichoke. The GitHub Actions workflow sets this to the latest trunk commit
+# SHA in the upstream Artichoke repository.
+#
+# If this build arg is not set via the docker command line, the `trunk` branch
+# is built.
+ARG ARTICHOKE_NIGHTLY_VER=latest
 # Install artichoke
 RUN set -eux; \
-    RUSTFLAGS="-C link-arg=-s" cargo install \
-    --git https://github.com/artichoke/artichoke \
-    --branch trunk \
-    --locked artichoke \
-    --target x86_64-unknown-linux-musl; \
+    if [[ "$ARTICHOKE_NIGHTLY_VER" == "latest" ]];then \
+      RUSTFLAGS="-C link-arg=-s" cargo install --target x86_64-unknown-linux-musl --git https://github.com/artichoke/artichoke --branch trunk --locked artichoke; \
+    else; \
+      RUSTFLAGS="-C link-arg=-s" cargo install --target x86_64-unknown-linux-musl --git https://github.com/artichoke/artichoke --rev "$ARTICHOKE_NIGHTLY_VER" --locked artichoke; \
+    fi; \
     airb --version; \
     artichoke --version;
 

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -63,7 +63,10 @@ ARG ARTICHOKE_NIGHTLY_VER=latest
 RUN apt-get install -y musl-tools
 # Install artichoke
 RUN set -eux; \
-    RUSTFLAGS="-C link-arg=-s" cargo install --git https://github.com/artichoke/artichoke --locked artichoke \
+    RUSTFLAGS="-C link-arg=-s" cargo install \
+    --git https://github.com/artichoke/artichoke \
+    --branch trunk \
+    --locked artichoke \
     --target x86_64-unknown-linux-musl; \
     airb --version; \
     artichoke --version;

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -68,7 +68,7 @@ ARG ARTICHOKE_NIGHTLY_VER=latest
 RUN set -eux; \
     if [[ "$ARTICHOKE_NIGHTLY_VER" == "latest" ]];then \
       RUSTFLAGS="-C link-arg=-s" cargo install --target x86_64-unknown-linux-musl --git https://github.com/artichoke/artichoke --branch trunk --locked artichoke; \
-    else; \
+    else \
       RUSTFLAGS="-C link-arg=-s" cargo install --target x86_64-unknown-linux-musl --git https://github.com/artichoke/artichoke --rev "$ARTICHOKE_NIGHTLY_VER" --locked artichoke; \
     fi; \
     airb --version; \

--- a/debian/buster/slim/Dockerfile
+++ b/debian/buster/slim/Dockerfile
@@ -61,7 +61,7 @@ ARG ARTICHOKE_NIGHTLY_VER=latest
 RUN set -eux; \
     if [[ "$ARTICHOKE_NIGHTLY_VER" == "latest" ]];then \
       RUSTFLAGS="-C link-arg=-s" cargo install --git https://github.com/artichoke/artichoke --branch trunk --locked artichoke; \
-    else; \
+    else \
       RUSTFLAGS="-C link-arg=-s" cargo install --git https://github.com/artichoke/artichoke --rev "$ARTICHOKE_NIGHTLY_VER" --locked artichoke; \
     fi; \
     airb --version; \

--- a/debian/buster/slim/Dockerfile
+++ b/debian/buster/slim/Dockerfile
@@ -50,17 +50,20 @@ RUN set -eux; \
     gem --version; \
     bundle --version;
 
-# XXX HACK - The `ARTICHOKE_NIGHTLY_VER` build arg is unused, but can be set at
-# build time to break layer caching and force a rebuild of Artichoke from latest
-# trunk. The GitHub Actions workflow sets this to the latest trunk commit SHA in
-# the upstream Artichoke repository.
+# The `ARTICHOKE_NIGHTLY_VER` build arg allows building a specific revision of
+# Artichoke. The GitHub Actions workflow sets this to the latest trunk commit
+# SHA in the upstream Artichoke repository.
+#
+# If this build arg is not set via the docker command line, the `trunk` branch
+# is built.
 ARG ARTICHOKE_NIGHTLY_VER=latest
 # Install artichoke
 RUN set -eux; \
-    RUSTFLAGS="-C link-arg=-s" cargo install \
-    --git https://github.com/artichoke/artichoke \
-    --branch trunk \
-    --locked artichoke; \
+    if [[ "$ARTICHOKE_NIGHTLY_VER" == "latest" ]];then \
+      RUSTFLAGS="-C link-arg=-s" cargo install --git https://github.com/artichoke/artichoke --branch trunk --locked artichoke; \
+    else; \
+      RUSTFLAGS="-C link-arg=-s" cargo install --git https://github.com/artichoke/artichoke --rev "$ARTICHOKE_NIGHTLY_VER" --locked artichoke; \
+    fi; \
     airb --version; \
     artichoke --version;
 

--- a/debian/buster/slim/Dockerfile
+++ b/debian/buster/slim/Dockerfile
@@ -57,7 +57,10 @@ RUN set -eux; \
 ARG ARTICHOKE_NIGHTLY_VER=latest
 # Install artichoke
 RUN set -eux; \
-    RUSTFLAGS="-C link-arg=-s" cargo install --git https://github.com/artichoke/artichoke --locked artichoke; \
+    RUSTFLAGS="-C link-arg=-s" cargo install \
+    --git https://github.com/artichoke/artichoke \
+    --branch trunk \
+    --locked artichoke; \
     airb --version; \
     artichoke --version;
 

--- a/ubuntu/bionic/Dockerfile
+++ b/ubuntu/bionic/Dockerfile
@@ -61,7 +61,7 @@ ARG ARTICHOKE_NIGHTLY_VER=latest
 RUN set -eux; \
     if [[ "$ARTICHOKE_NIGHTLY_VER" == "latest" ]];then \
       RUSTFLAGS="-C link-arg=-s" cargo install --git https://github.com/artichoke/artichoke --branch trunk --locked artichoke; \
-    else; \
+    else \
       RUSTFLAGS="-C link-arg=-s" cargo install --git https://github.com/artichoke/artichoke --rev "$ARTICHOKE_NIGHTLY_VER" --locked artichoke; \
     fi; \
     airb --version; \

--- a/ubuntu/bionic/Dockerfile
+++ b/ubuntu/bionic/Dockerfile
@@ -50,17 +50,20 @@ RUN set -eux; \
     gem --version; \
     bundle --version;
 
-# XXX HACK - The `ARTICHOKE_NIGHTLY_VER` build arg is unused, but can be set at
-# build time to break layer caching and force a rebuild of Artichoke from latest
-# trunk. The GitHub Actions workflow sets this to the latest trunk commit SHA in
-# the upstream Artichoke repository.
+# The `ARTICHOKE_NIGHTLY_VER` build arg allows building a specific revision of
+# Artichoke. The GitHub Actions workflow sets this to the latest trunk commit
+# SHA in the upstream Artichoke repository.
+#
+# If this build arg is not set via the docker command line, the `trunk` branch
+# is built.
 ARG ARTICHOKE_NIGHTLY_VER=latest
 # Install artichoke
 RUN set -eux; \
-    RUSTFLAGS="-C link-arg=-s" cargo install \
-    --git https://github.com/artichoke/artichoke \
-    --branch trunk \
-    --locked artichoke; \
+    if [[ "$ARTICHOKE_NIGHTLY_VER" == "latest" ]];then \
+      RUSTFLAGS="-C link-arg=-s" cargo install --git https://github.com/artichoke/artichoke --branch trunk --locked artichoke; \
+    else; \
+      RUSTFLAGS="-C link-arg=-s" cargo install --git https://github.com/artichoke/artichoke --rev "$ARTICHOKE_NIGHTLY_VER" --locked artichoke; \
+    fi; \
     airb --version; \
     artichoke --version;
 

--- a/ubuntu/bionic/Dockerfile
+++ b/ubuntu/bionic/Dockerfile
@@ -57,7 +57,10 @@ RUN set -eux; \
 ARG ARTICHOKE_NIGHTLY_VER=latest
 # Install artichoke
 RUN set -eux; \
-    RUSTFLAGS="-C link-arg=-s" cargo install --git https://github.com/artichoke/artichoke --locked artichoke; \
+    RUSTFLAGS="-C link-arg=-s" cargo install \
+    --git https://github.com/artichoke/artichoke \
+    --branch trunk \
+    --locked artichoke; \
     airb --version; \
     artichoke --version;
 


### PR DESCRIPTION
This PR updates the `Dockerfile`s to use `ARTICHOKE_NIGHTLY_VER` if set to anything other than `latest` to install a specific git revision. This matches the behavior of artichoke/nightly where the git revision is resolved at workflow-time and propagated through the installation workflow. This change ensures that the images tagged with a git SHA match the built artichoke they contain.

See also rust-lang/cargo#3517.

Breakage caused by artichoke/artichoke#961.