### PR TITLE
Update Dockerfiles for best practices and latest dep versions

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,31 +1,49 @@
 FROM ubuntu:18.04 AS build
 
-RUN apt-get update \
-    && apt-get install -y libssl-dev \
-    llvm-dev clang libclang-dev \
-    wget git cmake build-essential pkg-config
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bison \
+    build-essential \
+    ca-certificates \
+    clang \
+    cmake \
+    git \
+    libclang-dev \
+    libgdbm-dev \
+    libffi-dev \
+    libncurses5-dev \
+    libreadline-dev \
+    libssl-dev \
+    libyaml-dev \
+    llvm-dev \
+    musl-tools \
+    pkg-config \
+    wget \
+    xz-utils \
+    zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 # Rust setup
-ARG RUST_VERSION=1.44.0
+ARG RUST_VERSION=1.49.0
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH
 
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN set -eux; \
     dpkgArch="$(dpkg --print-architecture)"; \
     case "${dpkgArch##*-}" in \
-        amd64) rustArch='x86_64-unknown-linux-gnu'; rustupSha256='ad1f8b5199b3b9e231472ed7aa08d2e5d1d539198a15c5b1e53c746aad81d27b' ;; \
-        armhf) rustArch='armv7-unknown-linux-gnueabihf'; rustupSha256='6c6c3789dabf12171c7f500e06d21d8004b5318a5083df8b0b02c0e5ef1d017b' ;; \
-        arm64) rustArch='aarch64-unknown-linux-gnu'; rustupSha256='26942c80234bac34b3c1352abbd9187d3e23b43dae3cf56a9f9c1ea8ee53076d' ;; \
-        i386) rustArch='i686-unknown-linux-gnu'; rustupSha256='27ae12bc294a34e566579deba3e066245d09b8871dc021ef45fc715dced05297' ;; \
+        amd64) rustArch='x86_64-unknown-linux-gnu'; rustupSha256='ed7773edaf1d289656bdec2aacad12413b38ad0193fff54b2231f5140a4b07c5' ;; \
+        armhf) rustArch='armv7-unknown-linux-gnueabihf'; rustupSha256='7a7b9d246ad63358705d8d4a7d5c2ef1adfec24525d1d5c44a7739e1b867e84d' ;; \
+        arm64) rustArch='aarch64-unknown-linux-gnu'; rustupSha256='f80a0a792b3ab905ab4919474daf4d3f60e574fc6987e69bfba2fd877241a8de' ;; \
+        i386) rustArch='i686-unknown-linux-gnu'; rustupSha256='4473c18286aa1831683a772706d9a5c98b87a61cc014d38063e00a63a480afef' ;; \
         *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
     esac; \
-    url="https://static.rust-lang.org/rustup/archive/1.21.1/${rustArch}/rustup-init"; \
+    url="https://static.rust-lang.org/rustup/archive/1.23.1/${rustArch}/rustup-init"; \
     wget "$url"; \
     echo "${rustupSha256} *rustup-init" | sha256sum -c -; \
     chmod +x rustup-init; \
-    ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION; \
+    ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch}; \
     rm rustup-init; \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
     rustup --version; \
@@ -38,8 +56,8 @@ RUN set -eux; \
 
 # Ruby setup
 ARG RUBY_VERSION=2.6.3
-ARG RUBY_INSTALL_VERSION=0.7.0
-ARG RUBY_INSTALL_SHA=500a8ac84b8f65455958a02bcefd1ed4bfcaeaa2bb97b8f31e61ded5cd0fd70b
+ARG RUBY_INSTALL_VERSION=0.8.1
+ARG RUBY_INSTALL_SHA=d96fce7a4df70ca7a367400fbe035ff5b518408fc55924966743abf66ead7771
 
 RUN set -eux; \
     echo 'gem: --no-document' >> /usr/local/etc/gemrc; \
@@ -47,15 +65,12 @@ RUN set -eux; \
     wget -O /tmp/ruby-install.tar.gz "$url"; \
     echo "${RUBY_INSTALL_SHA} /tmp/ruby-install.tar.gz" | sha256sum -c -; \
     tar -xzvf /tmp/ruby-install.tar.gz -C /opt && rm /tmp/ruby-install.tar.gz; \
-    /opt/ruby-install-$RUBY_INSTALL_VERSION/bin/ruby-install -i /usr/local/ ruby $RUBY_VERSION -- --disable-install-rdoc; \
-    rm /usr/local/src/ruby-$RUBY_VERSION.tar.bz2; \
+    /opt/ruby-install-$RUBY_INSTALL_VERSION/bin/ruby-install --no-install-deps --install-dir /usr/local/ ruby $RUBY_VERSION -- --disable-install-rdoc; \
+    rm /usr/local/src/ruby-$RUBY_VERSION.tar.xz; \
     gem update --system; \
     ruby --version; \
     gem --version; \
     bundle --version;
-
-# Intall musl-gcc for alpine taget
-RUN apt-get install -y musl-tools
 
 # The `ARTICHOKE_NIGHTLY_VER` build arg allows building a specific revision of
 # Artichoke. The GitHub Actions workflow sets this to the latest trunk commit
@@ -66,7 +81,7 @@ RUN apt-get install -y musl-tools
 ARG ARTICHOKE_NIGHTLY_VER=latest
 # Install artichoke
 RUN set -eux; \
-    if [[ "$ARTICHOKE_NIGHTLY_VER" == "latest" ]]; then \
+    if [ "$ARTICHOKE_NIGHTLY_VER" = "latest" ]; then \
       RUSTFLAGS="-C link-arg=-s" cargo install --target x86_64-unknown-linux-musl --git https://github.com/artichoke/artichoke --branch trunk --locked artichoke; \
     else \
       RUSTFLAGS="-C link-arg=-s" cargo install --target x86_64-unknown-linux-musl --git https://github.com/artichoke/artichoke --rev "$ARTICHOKE_NIGHTLY_VER" --locked artichoke; \
@@ -88,6 +103,10 @@ LABEL org.opencontainers.image.description="Distribution of artichoke CLI and ai
 
 COPY --from=build /usr/local/cargo/bin/artichoke /opt/artichoke/bin/artichoke
 COPY --from=build /usr/local/cargo/bin/airb /opt/artichoke/bin/airb
+
+RUN addgroup --system --gid 128142 artichoke && \
+    adduser --system -G artichoke --uid 128142 artichoke
+USER artichoke
 
 ENV ARTICHOKE_BIN /opt/artichoke/bin
 ENV PATH $ARTICHOKE_BIN:$PATH

--- a/debian/buster/slim/Dockerfile
+++ b/debian/buster/slim/Dockerfile
@@ -1,31 +1,49 @@
 FROM debian:buster-slim AS build
 
-RUN apt-get update \
-    && apt-get install -y libssl-dev \
-    llvm-dev clang libclang-dev \
-    wget git cmake build-essential pkg-config
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bison \
+    build-essential \
+    ca-certificates \
+    clang \
+    cmake \
+    git \
+    libclang-dev \
+    libgdbm-dev \
+    libffi-dev \
+    libncurses5-dev \
+    libreadline-dev \
+    libssl-dev \
+    libyaml-dev \
+    llvm-dev \
+    musl-tools \
+    pkg-config \
+    wget \
+    xz-utils \
+    zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 # Rust setup
-ARG RUST_VERSION=1.44.0
+ARG RUST_VERSION=1.49.0
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH
 
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN set -eux; \
     dpkgArch="$(dpkg --print-architecture)"; \
     case "${dpkgArch##*-}" in \
-        amd64) rustArch='x86_64-unknown-linux-gnu'; rustupSha256='ad1f8b5199b3b9e231472ed7aa08d2e5d1d539198a15c5b1e53c746aad81d27b' ;; \
-        armhf) rustArch='armv7-unknown-linux-gnueabihf'; rustupSha256='6c6c3789dabf12171c7f500e06d21d8004b5318a5083df8b0b02c0e5ef1d017b' ;; \
-        arm64) rustArch='aarch64-unknown-linux-gnu'; rustupSha256='26942c80234bac34b3c1352abbd9187d3e23b43dae3cf56a9f9c1ea8ee53076d' ;; \
-        i386) rustArch='i686-unknown-linux-gnu'; rustupSha256='27ae12bc294a34e566579deba3e066245d09b8871dc021ef45fc715dced05297' ;; \
+        amd64) rustArch='x86_64-unknown-linux-gnu'; rustupSha256='ed7773edaf1d289656bdec2aacad12413b38ad0193fff54b2231f5140a4b07c5' ;; \
+        armhf) rustArch='armv7-unknown-linux-gnueabihf'; rustupSha256='7a7b9d246ad63358705d8d4a7d5c2ef1adfec24525d1d5c44a7739e1b867e84d' ;; \
+        arm64) rustArch='aarch64-unknown-linux-gnu'; rustupSha256='f80a0a792b3ab905ab4919474daf4d3f60e574fc6987e69bfba2fd877241a8de' ;; \
+        i386) rustArch='i686-unknown-linux-gnu'; rustupSha256='4473c18286aa1831683a772706d9a5c98b87a61cc014d38063e00a63a480afef' ;; \
         *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
     esac; \
-    url="https://static.rust-lang.org/rustup/archive/1.21.1/${rustArch}/rustup-init"; \
+    url="https://static.rust-lang.org/rustup/archive/1.23.1/${rustArch}/rustup-init"; \
     wget "$url"; \
     echo "${rustupSha256} *rustup-init" | sha256sum -c -; \
     chmod +x rustup-init; \
-    ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION; \
+    ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch}; \
     rm rustup-init; \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
     rustup --version; \
@@ -34,8 +52,8 @@ RUN set -eux; \
 
 # Ruby setup
 ARG RUBY_VERSION=2.6.3
-ARG RUBY_INSTALL_VERSION=0.7.0
-ARG RUBY_INSTALL_SHA=500a8ac84b8f65455958a02bcefd1ed4bfcaeaa2bb97b8f31e61ded5cd0fd70b
+ARG RUBY_INSTALL_VERSION=0.8.1
+ARG RUBY_INSTALL_SHA=d96fce7a4df70ca7a367400fbe035ff5b518408fc55924966743abf66ead7771
 
 RUN set -eux; \
     echo 'gem: --no-document' >> /usr/local/etc/gemrc; \
@@ -43,8 +61,8 @@ RUN set -eux; \
     wget -O /tmp/ruby-install.tar.gz "$url"; \
     echo "${RUBY_INSTALL_SHA} /tmp/ruby-install.tar.gz" | sha256sum -c -; \
     tar -xzvf /tmp/ruby-install.tar.gz -C /opt && rm /tmp/ruby-install.tar.gz; \
-    /opt/ruby-install-$RUBY_INSTALL_VERSION/bin/ruby-install -i /usr/local/ ruby $RUBY_VERSION -- --disable-install-rdoc; \
-    rm /usr/local/src/ruby-$RUBY_VERSION.tar.bz2; \
+    /opt/ruby-install-$RUBY_INSTALL_VERSION/bin/ruby-install --no-install-deps --install-dir /usr/local/ ruby $RUBY_VERSION -- --disable-install-rdoc; \
+    rm /usr/local/src/ruby-$RUBY_VERSION.tar.xz; \
     gem update --system; \
     ruby --version; \
     gem --version; \
@@ -59,7 +77,7 @@ RUN set -eux; \
 ARG ARTICHOKE_NIGHTLY_VER=latest
 # Install artichoke
 RUN set -eux; \
-    if [[ "$ARTICHOKE_NIGHTLY_VER" == "latest" ]]; then \
+    if [ "$ARTICHOKE_NIGHTLY_VER" = "latest" ]; then \
       RUSTFLAGS="-C link-arg=-s" cargo install --git https://github.com/artichoke/artichoke --branch trunk --locked artichoke; \
     else \
       RUSTFLAGS="-C link-arg=-s" cargo install --git https://github.com/artichoke/artichoke --rev "$ARTICHOKE_NIGHTLY_VER" --locked artichoke; \
@@ -81,6 +99,10 @@ LABEL org.opencontainers.image.description="Distribution of artichoke CLI and ai
 
 COPY --from=build /usr/local/cargo/bin/artichoke /opt/artichoke/bin/artichoke
 COPY --from=build /usr/local/cargo/bin/airb /opt/artichoke/bin/airb
+
+RUN groupadd --system --gid 128142 artichoke && \
+    useradd --no-log-init --system --gid artichoke --uid 128142 artichoke
+USER artichoke
 
 ENV ARTICHOKE_BIN /opt/artichoke/bin
 ENV PATH $ARTICHOKE_BIN:$PATH

--- a/ubuntu/bionic/Dockerfile
+++ b/ubuntu/bionic/Dockerfile
@@ -1,31 +1,49 @@
 FROM ubuntu:18.04 AS build
 
-RUN apt-get update \
-    && apt-get install -y libssl-dev \
-    llvm-dev clang libclang-dev \
-    wget git cmake build-essential pkg-config
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bison \
+    build-essential \
+    ca-certificates \
+    clang \
+    cmake \
+    git \
+    libclang-dev \
+    libgdbm-dev \
+    libffi-dev \
+    libncurses5-dev \
+    libreadline-dev \
+    libssl-dev \
+    libyaml-dev \
+    llvm-dev \
+    musl-tools \
+    pkg-config \
+    wget \
+    xz-utils \
+    zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 # Rust setup
-ARG RUST_VERSION=1.44.0
+ARG RUST_VERSION=1.49.0
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH
 
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN set -eux; \
     dpkgArch="$(dpkg --print-architecture)"; \
     case "${dpkgArch##*-}" in \
-        amd64) rustArch='x86_64-unknown-linux-gnu'; rustupSha256='ad1f8b5199b3b9e231472ed7aa08d2e5d1d539198a15c5b1e53c746aad81d27b' ;; \
-        armhf) rustArch='armv7-unknown-linux-gnueabihf'; rustupSha256='6c6c3789dabf12171c7f500e06d21d8004b5318a5083df8b0b02c0e5ef1d017b' ;; \
-        arm64) rustArch='aarch64-unknown-linux-gnu'; rustupSha256='26942c80234bac34b3c1352abbd9187d3e23b43dae3cf56a9f9c1ea8ee53076d' ;; \
-        i386) rustArch='i686-unknown-linux-gnu'; rustupSha256='27ae12bc294a34e566579deba3e066245d09b8871dc021ef45fc715dced05297' ;; \
+        amd64) rustArch='x86_64-unknown-linux-gnu'; rustupSha256='ed7773edaf1d289656bdec2aacad12413b38ad0193fff54b2231f5140a4b07c5' ;; \
+        armhf) rustArch='armv7-unknown-linux-gnueabihf'; rustupSha256='7a7b9d246ad63358705d8d4a7d5c2ef1adfec24525d1d5c44a7739e1b867e84d' ;; \
+        arm64) rustArch='aarch64-unknown-linux-gnu'; rustupSha256='f80a0a792b3ab905ab4919474daf4d3f60e574fc6987e69bfba2fd877241a8de' ;; \
+        i386) rustArch='i686-unknown-linux-gnu'; rustupSha256='4473c18286aa1831683a772706d9a5c98b87a61cc014d38063e00a63a480afef' ;; \
         *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
     esac; \
-    url="https://static.rust-lang.org/rustup/archive/1.21.1/${rustArch}/rustup-init"; \
+    url="https://static.rust-lang.org/rustup/archive/1.23.1/${rustArch}/rustup-init"; \
     wget "$url"; \
     echo "${rustupSha256} *rustup-init" | sha256sum -c -; \
     chmod +x rustup-init; \
-    ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION; \
+    ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch}; \
     rm rustup-init; \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
     rustup --version; \
@@ -34,8 +52,8 @@ RUN set -eux; \
 
 # Ruby setup
 ARG RUBY_VERSION=2.6.3
-ARG RUBY_INSTALL_VERSION=0.7.0
-ARG RUBY_INSTALL_SHA=500a8ac84b8f65455958a02bcefd1ed4bfcaeaa2bb97b8f31e61ded5cd0fd70b
+ARG RUBY_INSTALL_VERSION=0.8.1
+ARG RUBY_INSTALL_SHA=d96fce7a4df70ca7a367400fbe035ff5b518408fc55924966743abf66ead7771
 
 RUN set -eux; \
     echo 'gem: --no-document' >> /usr/local/etc/gemrc; \
@@ -43,8 +61,8 @@ RUN set -eux; \
     wget -O /tmp/ruby-install.tar.gz "$url"; \
     echo "${RUBY_INSTALL_SHA} /tmp/ruby-install.tar.gz" | sha256sum -c -; \
     tar -xzvf /tmp/ruby-install.tar.gz -C /opt && rm /tmp/ruby-install.tar.gz; \
-    /opt/ruby-install-$RUBY_INSTALL_VERSION/bin/ruby-install -i /usr/local/ ruby $RUBY_VERSION -- --disable-install-rdoc; \
-    rm /usr/local/src/ruby-$RUBY_VERSION.tar.bz2; \
+    /opt/ruby-install-$RUBY_INSTALL_VERSION/bin/ruby-install --no-install-deps --install-dir /usr/local/ ruby $RUBY_VERSION -- --disable-install-rdoc; \
+    rm /usr/local/src/ruby-$RUBY_VERSION.tar.xz; \
     gem update --system; \
     ruby --version; \
     gem --version; \
@@ -59,7 +77,7 @@ RUN set -eux; \
 ARG ARTICHOKE_NIGHTLY_VER=latest
 # Install artichoke
 RUN set -eux; \
-    if [[ "$ARTICHOKE_NIGHTLY_VER" == "latest" ]]; then \
+    if [ "$ARTICHOKE_NIGHTLY_VER" = "latest" ]; then \
       RUSTFLAGS="-C link-arg=-s" cargo install --git https://github.com/artichoke/artichoke --branch trunk --locked artichoke; \
     else \
       RUSTFLAGS="-C link-arg=-s" cargo install --git https://github.com/artichoke/artichoke --rev "$ARTICHOKE_NIGHTLY_VER" --locked artichoke; \
@@ -81,6 +99,10 @@ LABEL org.opencontainers.image.description="Distribution of artichoke CLI and ai
 
 COPY --from=build /usr/local/cargo/bin/artichoke /opt/artichoke/bin/artichoke
 COPY --from=build /usr/local/cargo/bin/airb /opt/artichoke/bin/airb
+
+RUN groupadd --system --gid 128142 artichoke && \
+    useradd --no-log-init --system --gid artichoke --uid 128142 artichoke
+USER artichoke
 
 ENV ARTICHOKE_BIN /opt/artichoke/bin
 ENV PATH $ARTICHOKE_BIN:$PATH


### PR DESCRIPTION
- Run `apt-get install` only once per `Dockerfile`.
- Run `rm -rf /var/lib/apt/lists/*` after `apt-get install`.
- Add `--no-install-recommends` flag to `apt-get install`.
- Add hidden deps to `apt-get install` that `ruby-install` was
  installing.
- Install `ca-certificates` for connecting to rust static site and
  verify certificate.
- Sort deps in `apt-get install` `RUN` statements.
- hadolint `DL4006`: Set the `SHELL` option `-o pipefail` before
  `RUN` with a pipe in.
- Update `RUST_VERSION` to 1.49.0.
- Update `rustup` to 1.23.1 from
  https://github.com/rust-lang/docker-rust/blob/a035f6f/1.49.0/buster/slim/Dockerfile.
- Update `ruby-install` to 0.8.1 from
  https://github.com/postmodern/ruby-install/releases/tag/v0.8.1.
- Pass `--no-install-deps` to `ruby-install`.
- Pass expanded `--install-dir` option to `ruby-install` instead of
  short `-i`.
- Use POSIX-compliant `[` test for `$ARTICHOKE_NIGHTLY_VER` conditional
  `cargo install` step.
- Run the resulting container with a non-root user `artichoke` with GID/UID >
  10,000.