### PR TITLE
Set RUST_VERSION arg to 1.50.0

### DIFF
--- a/.github/workflows/dockerfile.yaml
+++ b/.github/workflows/dockerfile.yaml
@@ -1,0 +1,63 @@
+---
+name: Docker Image CI (defaults)
+"on":
+  push:
+    branches:
+      - trunk
+  pull_request:
+    branches:
+      - trunk
+  schedule:
+    - cron: "0 0 * * TUE"
+
+jobs:
+  ubuntu-bionic:
+    name: Ubuntu 18.04 Bionic
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ubuntu/bionic/Dockerfile
+          push: false
+
+  debian-buster-slim:
+    name: Debian Buster Slim
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: debian/buster/slim/Dockerfile
+          push: false
+
+  alpine:
+    name: Alpine 3
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: alpine/Dockerfile
+          push: false

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Rust setup
-ARG RUST_VERSION=1.49.0
+ARG RUST_VERSION=1.50.0
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \

--- a/debian/buster/slim/Dockerfile
+++ b/debian/buster/slim/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Rust setup
-ARG RUST_VERSION=1.49.0
+ARG RUST_VERSION=1.50.0
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \

--- a/ubuntu/bionic/Dockerfile
+++ b/ubuntu/bionic/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Rust setup
-ARG RUST_VERSION=1.49.0
+ARG RUST_VERSION=1.50.0
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \


### PR DESCRIPTION
artichoke requires at least rustc 1.50.0 to compile.

Add a GitHub Actions workflow for testing the `Dockerfile` default args.