### PR TITLE
Upgrade Alpine image build container to Ubuntu 20.04 Focal

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,6 +1,6 @@
-FROM ubuntu:18.04 AS build
+FROM ubuntu:20.04 AS build
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     bison \
     build-essential \
     ca-certificates \

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -50,10 +50,6 @@ RUN set -eux; \
     cargo --version; \
     rustc --version;
 
-# Add libmusl support for Alpine
-RUN set -eux; \
-    rustup target add x86_64-unknown-linux-musl
-
 # Ruby setup
 ARG RUBY_VERSION=2.6.3
 ARG RUBY_INSTALL_VERSION=0.8.1
@@ -71,6 +67,10 @@ RUN set -eux; \
     ruby --version; \
     gem --version; \
     bundle --version;
+
+# Add libmusl support for Alpine
+RUN set -eux; \
+    rustup target add x86_64-unknown-linux-musl
 
 # The `ARTICHOKE_NIGHTLY_VER` build arg allows building a specific revision of
 # Artichoke. The GitHub Actions workflow sets this to the latest trunk commit


### PR DESCRIPTION
This PR also reorders some `RUN` steps to allow the build of Ruby to be cached between the `ubuntu` and `alpine` Dockerfiles.