### PR TITLE
Add GitHub Actions cache mode to docker/build-push-action

### DIFF
--- a/.github/workflows/docker-nightly.yaml
+++ b/.github/workflows/docker-nightly.yaml
@@ -63,6 +63,8 @@ jobs:
           build-args: |
             ARTICHOKE_NIGHTLY_VER=${{ steps.latest.outputs.commit }}
             RUST_VERSION=${{ steps.rust_toolchain.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   debian-slim:
     name: Debian Slim
@@ -113,6 +115,8 @@ jobs:
           build-args: |
             ARTICHOKE_NIGHTLY_VER=${{ steps.latest.outputs.commit }}
             RUST_VERSION=${{ steps.rust_toolchain.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   alpine:
     name: Alpine
@@ -163,3 +167,5 @@ jobs:
           build-args: |
             ARTICHOKE_NIGHTLY_VER=${{ steps.latest.outputs.commit }}
             RUST_VERSION=${{ steps.rust_toolchain.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/dockerfile.yaml
+++ b/.github/workflows/dockerfile.yaml
@@ -27,6 +27,8 @@ jobs:
           context: .
           file: ubuntu/focal/Dockerfile
           push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   debian-slim:
     name: Debian Slim
@@ -44,6 +46,8 @@ jobs:
           context: .
           file: debian/bullseye/slim/Dockerfile
           push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   alpine:
     name: Alpine
@@ -61,3 +65,5 @@ jobs:
           context: .
           file: alpine/Dockerfile
           push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
See docker/build-push-action#406, docker/buildx#535.