### PR TITLE
Install bindgen as a cacheable RUN step

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -72,6 +72,11 @@ RUN set -eux; \
 RUN set -eux; \
     rustup target add x86_64-unknown-linux-musl
 
+# Install bindgen
+RUN set -eux; \
+    cargo install --version 0.59.1 bindgen; \
+    bindgen --version
+
 # The `ARTICHOKE_NIGHTLY_VER` build arg allows building a specific revision of
 # Artichoke. The GitHub Actions workflow sets this to the latest trunk commit
 # SHA in the upstream Artichoke repository.

--- a/debian/bullseye/slim/Dockerfile
+++ b/debian/bullseye/slim/Dockerfile
@@ -68,6 +68,11 @@ RUN set -eux; \
     gem --version; \
     bundle --version;
 
+# Install bindgen
+RUN set -eux; \
+    cargo install --version 0.59.1 bindgen; \
+    bindgen --version
+
 # The `ARTICHOKE_NIGHTLY_VER` build arg allows building a specific revision of
 # Artichoke. The GitHub Actions workflow sets this to the latest trunk commit
 # SHA in the upstream Artichoke repository.

--- a/ubuntu/focal/Dockerfile
+++ b/ubuntu/focal/Dockerfile
@@ -68,6 +68,11 @@ RUN set -eux; \
     gem --version; \
     bundle --version;
 
+# Install bindgen
+RUN set -eux; \
+    cargo install --version 0.59.1 bindgen; \
+    bindgen --version
+
 # The `ARTICHOKE_NIGHTLY_VER` build arg allows building a specific revision of
 # Artichoke. The GitHub Actions workflow sets this to the latest trunk commit
 # SHA in the upstream Artichoke repository.


### PR DESCRIPTION
This pulls the implicit install out of the `cargo install artichoke` step which is expected to not be cached very much.