### PR TITLE
Remove caching from docker builds

### DIFF
--- a/.github/workflows/docker-nightly.yaml
+++ b/.github/workflows/docker-nightly.yaml
@@ -63,8 +63,6 @@ jobs:
           build-args: |
             ARTICHOKE_NIGHTLY_VER=${{ steps.latest.outputs.commit }}
             RUST_VERSION=${{ steps.rust_toolchain.outputs.version }}
-          cache-from: type=gha,scope=docker-nightly-${{ github.workflow }}-${{ github.job }}-${{ runner.os }}-v1
-          cache-to: type=gha,mode=max,scope=docker-nightly-${{ github.workflow }}-${{ github.job }}-${{ runner.os }}-v1
 
   debian-slim:
     name: Debian Slim
@@ -115,8 +113,6 @@ jobs:
           build-args: |
             ARTICHOKE_NIGHTLY_VER=${{ steps.latest.outputs.commit }}
             RUST_VERSION=${{ steps.rust_toolchain.outputs.version }}
-          cache-from: type=gha,scope=docker-nightly-${{ github.workflow }}-${{ github.job }}-${{ runner.os }}-v1
-          cache-to: type=gha,mode=max,scope=docker-nightly-${{ github.workflow }}-${{ github.job }}-${{ runner.os }}-v1
 
   alpine:
     name: Alpine
@@ -167,5 +163,3 @@ jobs:
           build-args: |
             ARTICHOKE_NIGHTLY_VER=${{ steps.latest.outputs.commit }}
             RUST_VERSION=${{ steps.rust_toolchain.outputs.version }}
-          cache-from: type=gha,scope=docker-nightly-${{ github.workflow }}-${{ github.job }}-${{ runner.os }}-v1
-          cache-to: type=gha,mode=max,scope=docker-nightly-${{ github.workflow }}-${{ github.job }}-${{ runner.os }}-v1

--- a/.github/workflows/dockerfile.yaml
+++ b/.github/workflows/dockerfile.yaml
@@ -27,8 +27,6 @@ jobs:
           context: .
           file: ubuntu/focal/Dockerfile
           push: false
-          cache-from: type=gha,scope=docker-defaults-${{ github.workflow }}-${{ github.job }}-${{ runner.os }}-v1
-          cache-to: type=gha,mode=max,scope=docker-defaults-${{ github.workflow }}-${{ github.job }}-${{ runner.os }}-v1
 
   debian-slim:
     name: Debian Slim
@@ -46,8 +44,6 @@ jobs:
           context: .
           file: debian/bullseye/slim/Dockerfile
           push: false
-          cache-from: type=gha,scope=docker-defaults-${{ github.workflow }}-${{ github.job }}-${{ runner.os }}-v1
-          cache-to: type=gha,mode=max,scope=docker-defaults-${{ github.workflow }}-${{ github.job }}-${{ runner.os }}-v1
 
   alpine:
     name: Alpine
@@ -65,5 +61,3 @@ jobs:
           context: .
           file: alpine/Dockerfile
           push: false
-          cache-from: type=gha,scope=docker-defaults-${{ github.workflow }}-${{ github.job }}-${{ runner.os }}-v1
-          cache-to: type=gha,mode=max,scope=docker-defaults-${{ github.workflow }}-${{ github.job }}-${{ runner.os }}-v1


### PR DESCRIPTION
There are still some bugs in the `gha` cache backend that are causing
builds to fail:

- docker/buildx#681
- docker/build-push-action#422

Removing caching until upstream resolves these issues.