### PR TITLE
Fix broken CI builds when secrets are unavailable

### DIFF
--- a/.github/workflows/docker-nightly.yaml
+++ b/.github/workflows/docker-nightly.yaml
@@ -43,6 +43,7 @@ jobs:
 
       - name: Login to DockerHub
         uses: docker/login-action@v1
+        if: ${{ github.ref == 'refs/heads/trunk' }}
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -96,6 +97,7 @@ jobs:
 
       - name: Login to DockerHub
         uses: docker/login-action@v1
+        if: ${{ github.ref == 'refs/heads/trunk' }}
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -146,6 +148,7 @@ jobs:
 
       - name: Login to DockerHub
         uses: docker/login-action@v1
+        if: ${{ github.ref == 'refs/heads/trunk' }}
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
@dependabot does not have access to secrets when pushing dependency
update PRs, which makes the nightly builder fail when logging into
Docker Hub.

Logging into Docker Hub is only necessary when pushing images, which
only happens on `trunk`. Add a conditional `if` to this job step to skip
logging into Docker Hub for PRs.