### PR TITLE
Bump RUST_VERSION Dockerfile arg to 1.56.1

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y --no
     && rm -rf /var/lib/apt/lists/*
 
 # Rust setup
-ARG RUST_VERSION=1.54.0
+ARG RUST_VERSION=1.56.1
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \

--- a/debian/bullseye/slim/Dockerfile
+++ b/debian/bullseye/slim/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Rust setup
-ARG RUST_VERSION=1.54.0
+ARG RUST_VERSION=1.56.1
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \

--- a/ubuntu/focal/Dockerfile
+++ b/ubuntu/focal/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y --no
     && rm -rf /var/lib/apt/lists/*
 
 # Rust setup
-ARG RUST_VERSION=1.54.0
+ARG RUST_VERSION=1.56.1
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \


### PR DESCRIPTION
See:

- https://github.com/artichoke/artichoke/pull/1452
- https://github.com/artichoke/artichoke/pull/1453

See https://blog.rust-lang.org/2021/11/01/cve-2021-42574.html for why this bump goes beyond the current pegged 1.56.0 toolchain.

See:

- https://github.com/artichoke/artichoke/pull/1486