### PR TITLE
Bump default Rust version to 1.58.0

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y --no
     && rm -rf /var/lib/apt/lists/*
 
 # Rust setup
-ARG RUST_VERSION=1.57.0
+ARG RUST_VERSION=1.58.0
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \

--- a/debian/bullseye/slim/Dockerfile
+++ b/debian/bullseye/slim/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Rust setup
-ARG RUST_VERSION=1.57.0
+ARG RUST_VERSION=1.58.0
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \

--- a/ubuntu/focal/Dockerfile
+++ b/ubuntu/focal/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y --no
     && rm -rf /var/lib/apt/lists/*
 
 # Rust setup
-ARG RUST_VERSION=1.57.0
+ARG RUST_VERSION=1.58.0
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \


### PR DESCRIPTION
```sh
rg -l 'ARG RUST_VERSION=' | xargs sed -i '' -e 's/ARG RUST_VERSION=1.57.0/ARG RUST_VERSION=1.58.0/g'
```

See upstream PR which necessitated this change:

- https://github.com/artichoke/artichoke/pull/1637