### PR TITLE
Remove Ruby from all `Dockerfile`s

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -55,24 +55,6 @@ COPY <<EOF $CARGO_HOME/config.toml
 git-fetch-with-cli = true
 EOF
 
-# Ruby setup
-ARG RUBY_VERSION=3.0.2
-ARG RUBY_INSTALL_VERSION=0.8.3
-ARG RUBY_INSTALL_SHA=e2f69949757d032d48ee5c028be020bdc8863c41d5648b53328903d2e16ab3b2
-
-RUN set -eux; \
-    echo 'gem: --no-document' >> /usr/local/etc/gemrc; \
-    url="https://github.com/postmodern/ruby-install/archive/v$RUBY_INSTALL_VERSION.tar.gz"; \
-    wget --progress=dot:giga -O /tmp/ruby-install.tar.gz "$url"; \
-    echo "${RUBY_INSTALL_SHA} /tmp/ruby-install.tar.gz" | sha256sum -c -; \
-    tar -xzvf /tmp/ruby-install.tar.gz -C /opt && rm /tmp/ruby-install.tar.gz; \
-    /opt/ruby-install-$RUBY_INSTALL_VERSION/bin/ruby-install --no-install-deps --install-dir /usr/local/ ruby $RUBY_VERSION -- --disable-install-rdoc; \
-    rm /usr/local/src/ruby-$RUBY_VERSION.tar.xz; \
-    gem update --system; \
-    ruby --version; \
-    gem --version; \
-    bundle --version;
-
 # Add libmusl support for Alpine
 RUN set -eux; \
     rustup target add x86_64-unknown-linux-musl

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,25 +1,15 @@
 FROM ubuntu:20.04 AS build
 
 RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    bison \
     build-essential \
     ca-certificates \
     clang \
-    cmake \
     git \
     libclang-dev \
-    libgdbm-dev \
-    libffi-dev \
-    libncurses5-dev \
-    libreadline-dev \
-    libssl-dev \
-    libyaml-dev \
     llvm-dev \
     musl-tools \
     pkg-config \
     wget \
-    xz-utils \
-    zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Rust setup

--- a/debian/bullseye/slim/Dockerfile
+++ b/debian/bullseye/slim/Dockerfile
@@ -55,24 +55,6 @@ COPY <<EOF $CARGO_HOME/config.toml
 git-fetch-with-cli = true
 EOF
 
-# Ruby setup
-ARG RUBY_VERSION=3.0.2
-ARG RUBY_INSTALL_VERSION=0.8.3
-ARG RUBY_INSTALL_SHA=e2f69949757d032d48ee5c028be020bdc8863c41d5648b53328903d2e16ab3b2
-
-RUN set -eux; \
-    echo 'gem: --no-document' >> /usr/local/etc/gemrc; \
-    url="https://github.com/postmodern/ruby-install/archive/v$RUBY_INSTALL_VERSION.tar.gz"; \
-    wget --progress=dot:giga -O /tmp/ruby-install.tar.gz "$url"; \
-    echo "${RUBY_INSTALL_SHA} /tmp/ruby-install.tar.gz" | sha256sum -c -; \
-    tar -xzvf /tmp/ruby-install.tar.gz -C /opt && rm /tmp/ruby-install.tar.gz; \
-    /opt/ruby-install-$RUBY_INSTALL_VERSION/bin/ruby-install --no-install-deps --install-dir /usr/local/ ruby $RUBY_VERSION -- --disable-install-rdoc; \
-    rm /usr/local/src/ruby-$RUBY_VERSION.tar.xz; \
-    gem update --system; \
-    ruby --version; \
-    gem --version; \
-    bundle --version;
-
 # Install bindgen
 RUN set -eux; \
     cargo install --version 0.59.1 bindgen; \

--- a/debian/bullseye/slim/Dockerfile
+++ b/debian/bullseye/slim/Dockerfile
@@ -1,25 +1,15 @@
 FROM debian:bullseye-slim AS build
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    bison \
     build-essential \
     ca-certificates \
     clang \
-    cmake \
     git \
     libclang-dev \
-    libgdbm-dev \
-    libffi-dev \
-    libncurses5-dev \
-    libreadline-dev \
-    libssl-dev \
-    libyaml-dev \
     llvm-dev \
     musl-tools \
     pkg-config \
     wget \
-    xz-utils \
-    zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Rust setup

--- a/debian/bullseye/slim/Dockerfile
+++ b/debian/bullseye/slim/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     libclang-dev \
     llvm-dev \
-    musl-tools \
     pkg-config \
     wget \
     && rm -rf /var/lib/apt/lists/*

--- a/ubuntu/focal/Dockerfile
+++ b/ubuntu/focal/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y --no
     git \
     libclang-dev \
     llvm-dev \
-    musl-tools \
     pkg-config \
     wget \
     && rm -rf /var/lib/apt/lists/*

--- a/ubuntu/focal/Dockerfile
+++ b/ubuntu/focal/Dockerfile
@@ -55,24 +55,6 @@ COPY <<EOF $CARGO_HOME/config.toml
 git-fetch-with-cli = true
 EOF
 
-# Ruby setup
-ARG RUBY_VERSION=3.0.2
-ARG RUBY_INSTALL_VERSION=0.8.3
-ARG RUBY_INSTALL_SHA=e2f69949757d032d48ee5c028be020bdc8863c41d5648b53328903d2e16ab3b2
-
-RUN set -eux; \
-    echo 'gem: --no-document' >> /usr/local/etc/gemrc; \
-    url="https://github.com/postmodern/ruby-install/archive/v$RUBY_INSTALL_VERSION.tar.gz"; \
-    wget --progress=dot:giga -O /tmp/ruby-install.tar.gz "$url"; \
-    echo "${RUBY_INSTALL_SHA} /tmp/ruby-install.tar.gz" | sha256sum -c -; \
-    tar -xzvf /tmp/ruby-install.tar.gz -C /opt && rm /tmp/ruby-install.tar.gz; \
-    /opt/ruby-install-$RUBY_INSTALL_VERSION/bin/ruby-install --no-install-deps --install-dir /usr/local/ ruby $RUBY_VERSION -- --disable-install-rdoc; \
-    rm /usr/local/src/ruby-$RUBY_VERSION.tar.xz; \
-    gem update --system; \
-    ruby --version; \
-    gem --version; \
-    bundle --version;
-
 # Install bindgen
 RUN set -eux; \
     cargo install --version 0.59.1 bindgen; \

--- a/ubuntu/focal/Dockerfile
+++ b/ubuntu/focal/Dockerfile
@@ -1,25 +1,15 @@
 FROM ubuntu:20.04 AS build
 
 RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    bison \
     build-essential \
     ca-certificates \
     clang \
-    cmake \
     git \
     libclang-dev \
-    libgdbm-dev \
-    libffi-dev \
-    libncurses5-dev \
-    libreadline-dev \
-    libssl-dev \
-    libyaml-dev \
     llvm-dev \
     musl-tools \
     pkg-config \
     wget \
-    xz-utils \
-    zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Rust setup


### PR DESCRIPTION
Artichoke no longer requires Ruby to build. This should shave a bunch of
time off of image builds.

Fixes #82.

See upstream changes that enabled this:

- artichoke/artichoke#1756