### PR TITLE
Don't install 'build-essential' in build stage

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -3,7 +3,6 @@ FROM ubuntu:20.04 AS build
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    build-essential \
     ca-certificates \
     clang \
     git \

--- a/debian/bullseye/slim/Dockerfile
+++ b/debian/bullseye/slim/Dockerfile
@@ -3,7 +3,6 @@ FROM debian:bullseye-slim AS build
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential \
     ca-certificates \
     clang \
     git \

--- a/ubuntu/focal/Dockerfile
+++ b/ubuntu/focal/Dockerfile
@@ -3,7 +3,6 @@ FROM ubuntu:20.04 AS build
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    build-essential \
     ca-certificates \
     clang \
     git \


### PR DESCRIPTION
Per https://packages.debian.org/bullseye/build-essential, this meta package brings in:

- dpkg-dev
- g++
- gcc
- libc6-dev
- make

because the container already pulls in clang, none of these deps are required. Remove this virtual package to speed up container build time.