### PR TITLE
Don't install 'llvm-dev' in build stage

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y --no
     clang \
     git \
     libclang-dev \
-    llvm-dev \
     musl-tools \
     pkg-config \
     wget \

--- a/debian/bullseye/slim/Dockerfile
+++ b/debian/bullseye/slim/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     clang \
     git \
     libclang-dev \
-    llvm-dev \
     pkg-config \
     wget \
     && rm -rf /var/lib/apt/lists/*

--- a/ubuntu/focal/Dockerfile
+++ b/ubuntu/focal/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y --no
     clang \
     git \
     libclang-dev \
-    llvm-dev \
     pkg-config \
     wget \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
It looks like this package brings in a bunch of stuff we don't need, especially since the Dockerfiles already install `libclang-dev`. Let's see if the build works!

https://packages.debian.org/bullseye/llvm-dev