### PR TITLE
Remove `.cargo/config.toml` snippets to use git CLI

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -38,11 +38,6 @@ RUN set -eux; \
     cargo --version; \
     rustc --version;
 
-COPY <<EOF $CARGO_HOME/config.toml
-[net]
-git-fetch-with-cli = true
-EOF
-
 # Add libmusl support for Alpine
 RUN set -eux; \
     rustup target add x86_64-unknown-linux-musl

--- a/debian/bullseye/slim/Dockerfile
+++ b/debian/bullseye/slim/Dockerfile
@@ -37,11 +37,6 @@ RUN set -eux; \
     cargo --version; \
     rustc --version;
 
-COPY <<EOF $CARGO_HOME/config.toml
-[net]
-git-fetch-with-cli = true
-EOF
-
 # Install bindgen
 RUN set -eux; \
     cargo install --version 0.59.1 bindgen; \

--- a/ubuntu/focal/Dockerfile
+++ b/ubuntu/focal/Dockerfile
@@ -37,11 +37,6 @@ RUN set -eux; \
     cargo --version; \
     rustc --version;
 
-COPY <<EOF $CARGO_HOME/config.toml
-[net]
-git-fetch-with-cli = true
-EOF
-
 # Install bindgen
 RUN set -eux; \
     cargo install --version 0.59.1 bindgen; \


### PR DESCRIPTION
Since https://github.com/artichoke/artichoke/issues/1826 has been fixed,
git clones happen much more quickly for Artichoke, so this workaround to
use the native git CLI is not necessary.

Additionally, the heredoc syntax feature of `Dockerfile`s that these
`COPY` instructions used requires syntax annotations [0] in the
`Dockerfile` sources that were not present.

[0] https://github.com/moby/buildkit/blob/86c33b66e176a6fc74b88d6f46798d3ec18e2e73/frontend/dockerfile/docs/syntax.md#here-documents

Per the docs:

> This feature is available since `docker/dockerfile:1.4.0` release.
>
>     # syntax=docker/dockerfile:1.4

These annotations are not present in the `Dockerfile`s in this
repository. I discovered this misconfiguration when attempting to build
with docker and buildx on Ubuntu in WSL. I'm not sure how this works in
CI.