### PR TITLE
Upgrade Rust toolchain to 1.62.0

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -55,7 +55,7 @@ namespace :release do
   end
 end
 
-RUST_VERSION = '1.60.0'
+RUST_VERSION = '1.62.0'
 
 namespace :toolchain do
   desc 'Sync Rust toolchain to all sources'

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y --no
     && rm -rf /var/lib/apt/lists/*
 
 # Rust setup
-ARG RUST_VERSION=1.60.0
+ARG RUST_VERSION=1.62.0
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \

--- a/debian/bullseye/slim/Dockerfile
+++ b/debian/bullseye/slim/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Rust setup
-ARG RUST_VERSION=1.60.0
+ARG RUST_VERSION=1.62.0
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \

--- a/ubuntu/focal/Dockerfile
+++ b/ubuntu/focal/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y --no
     && rm -rf /var/lib/apt/lists/*
 
 # Rust setup
-ARG RUST_VERSION=1.60.0
+ARG RUST_VERSION=1.62.0
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \


### PR DESCRIPTION
Preparation for the toolchain upgrade in artichoke/artichoke:

- https://github.com/artichoke/artichoke/pull/1931