### PR TITLE
Use stable v1.0.0 release of artichoke/generate_third_party

### DIFF
--- a/.github/workflows/docker-nightly.yaml
+++ b/.github/workflows/docker-nightly.yaml
@@ -62,8 +62,7 @@ jobs:
           echo "::set-output name=version::$(cat rust-toolchain)"
 
       - name: Generate THIRDPARTY license listing
-        id: generate_third_party
-        uses: artichoke/generate_third_party@trunk
+        uses: artichoke/generate_third_party@v1.0.0
         with:
           artichoke_ref: ${{ steps.latest.outputs.commit }}
           target_triple: ${{ matrix.target_triple }}


### PR DESCRIPTION
Remove id from job step since it is no longer needed for capturing output.