### PR TITLE
Add support for arm64 multi-arch Debian and Ubuntu images

### DIFF
--- a/.github/workflows/docker-nightly.yaml
+++ b/.github/workflows/docker-nightly.yaml
@@ -25,16 +25,19 @@ jobs:
           - build: alpine
             target_triple: x86_64-unknown-linux-musl
             dockerfile: alpine/Dockerfile
+            docker_target_platforms: linux/amd64
             tag_bare: alpine
             tag_version: alpine3
           - build: debian
             target_triple: x86_64-unknown-linux-gnu
             dockerfile: debian/bullseye/slim/Dockerfile
+            docker_target_platforms: linux/amd64,linux/arm64
             tag_bare: slim
             tag_version: slim-bullseye
           - build: ubuntu
             target_triple: x86_64-unknown-linux-gnu
             dockerfile: ubuntu/focal/Dockerfile
+            docker_target_platforms: linux/amd64,linux/arm64
             tag_bare: ubuntu
             tag_version: ubuntu-focal
 
@@ -86,7 +89,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.docker_target_platforms }}
           file: ${{ matrix.dockerfile }}
           push: ${{ github.ref == 'refs/heads/trunk' }}
           tags: |
@@ -104,7 +107,7 @@ jobs:
         if: matrix.build == 'ubuntu'
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.docker_target_platforms }}
           file: ${{ matrix.dockerfile }}
           push: ${{ github.ref == 'refs/heads/trunk' }}
           tags: |

--- a/.github/workflows/docker-nightly.yaml
+++ b/.github/workflows/docker-nightly.yaml
@@ -69,6 +69,9 @@ jobs:
           output_file: ${{ github.workspace }}/THIRDPARTY
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
@@ -83,6 +86,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           file: ${{ matrix.dockerfile }}
           push: ${{ github.ref == 'refs/heads/trunk' }}
           tags: |
@@ -100,6 +104,7 @@ jobs:
         if: matrix.build == 'ubuntu'
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           file: ${{ matrix.dockerfile }}
           push: ${{ github.ref == 'refs/heads/trunk' }}
           tags: |

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Currently supported docker platforms are:
 - `ARTICHOKE_NIGHTLY_VER` - Argument used for cache invalidation (see
   `Dockerfile`), defaults to SHA of latest trunk commit in upstream Artichoke
   repository.
+- `BINDGEN_VERSION` - Rust bindgen version.
 
 [artichoke-repo]: https://github.com/artichoke/artichoke
 [docker-hub]: https://hub.docker.com/r/artichokeruby/artichoke

--- a/README.md
+++ b/README.md
@@ -30,9 +30,13 @@ Currently supported docker platforms are:
 
 - `ubuntu` - canonical mainline Ubuntu 20.04 Focal Fossa image, tagged with
   `latest`, `ubuntu-nightly`, `ubuntu-focal-nightly`, and `ubuntu20.04-nightly`.
+  Ubuntu images are multi-arch images with `linux/amd64` and `linux/arm64`
+  support.
 - `debian-slim` - Debian 11 (Bullseye) slim image, tagged `slim-nightly` and
-  `slim-bullseye-nightly`.
+  `slim-bullseye-nightly`. Debian images are multi-arch images with
+  `linux/amd64` and `linux/arm64` support.
 - `alpine` - Alpine 3 image, tagged with `alpine-nightly` and `alpine3-nightly`.
+  Alpine images only have `linux/amd64` architecture support.
 
 #### Secrets
 

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -52,6 +52,9 @@ ENV CC_aarch64_unknown_linux_musl=clang
 ENV AR_aarch64_unknown_linux_musl=llvm-ar
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS="-Clink-self-contained=yes -Clinker=rust-lld"
 
+# https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli
+ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
+
 # Install bindgen
 ARG BINDGEN_VERSION=0.60.1
 RUN set -eux; \

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -57,10 +57,16 @@ RUN set -eux; \
 ARG ARTICHOKE_NIGHTLY_VER=latest
 # Install artichoke
 RUN set -eux; \
+    dpkgArch="$(dpkg --print-architecture)"; \
+    case "${dpkgArch##*-}" in \
+        amd64) targetArch='x86_64-unknown-linux-musl' ;; \
+        arm64) targetArch='aarch64-unknown-linux-musl' ;; \
+        *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
+    esac; \
     if [ "$ARTICHOKE_NIGHTLY_VER" = "latest" ]; then \
-      RUSTFLAGS="-C link-arg=-s" cargo install --target x86_64-unknown-linux-musl --git https://github.com/artichoke/artichoke --branch trunk --locked artichoke; \
+      RUSTFLAGS="-C link-arg=-s" cargo install --target "$targetArch" --git https://github.com/artichoke/artichoke --branch trunk --locked artichoke; \
     else \
-      RUSTFLAGS="-C link-arg=-s" cargo install --target x86_64-unknown-linux-musl --git https://github.com/artichoke/artichoke --rev "$ARTICHOKE_NIGHTLY_VER" --locked artichoke; \
+      RUSTFLAGS="-C link-arg=-s" cargo install --target "$targetArch" --git https://github.com/artichoke/artichoke --rev "$ARTICHOKE_NIGHTLY_VER" --locked artichoke; \
     fi; \
     airb --version; \
     artichoke --version; \

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -78,7 +78,7 @@ RUN set -eux; \
     case "${TARGETARCH}" in \
         amd64) artichokeArch='x86_64-unknown-linux-musl' ;; \
         arm64) artichokeArch='aarch64-unknown-linux-musl' ;; \
-        *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
+        *) echo >&2 "unsupported architecture: ${TARGETARCH}"; exit 1 ;; \
     esac; \
     if [ "$ARTICHOKE_NIGHTLY_VER" = "latest" ]; then \
       cargo install \

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -95,8 +95,6 @@ RUN set -eux; \
         --locked \
         artichoke; \
     fi; \
-    airb --version; \
-    artichoke --version; \
     mkdir /target; \
     touch /target/THIRDPARTY;
 

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -39,7 +39,7 @@ RUN set -eux; \
     cargo --version; \
     rustc --version;
 
-# Add libmusl support for Alpine
+# Add multi-platform musl target support
 RUN set -eux; \
     rustup target add x86_64-unknown-linux-musl; \
     rustup target add aarch64-unknown-linux-musl;

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -64,14 +64,14 @@ RUN set -eux; \
         *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
     esac; \
     if [ "$ARTICHOKE_NIGHTLY_VER" = "latest" ]; then \
-      RUSTFLAGS="-C link-arg=-s" cargo install \
+      cargo install \
         --target "$artichokeArch" \
         --git https://github.com/artichoke/artichoke \
         --branch trunk \
         --locked \
         artichoke; \
     else \
-      RUSTFLAGS="-C link-arg=-s"  cargo install \
+      cargo install \
         --target "$artichokeArch" \
         --git https://github.com/artichoke/artichoke \
         --rev "$ARTICHOKE_NIGHTLY_VER" \

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -59,14 +59,14 @@ ARG ARTICHOKE_NIGHTLY_VER=latest
 RUN set -eux; \
     dpkgArch="$(dpkg --print-architecture)"; \
     case "${dpkgArch##*-}" in \
-        amd64) targetArch='x86_64-unknown-linux-musl' ;; \
-        arm64) targetArch='aarch64-unknown-linux-musl' ;; \
+        amd64) artichokeArch='x86_64-unknown-linux-musl' ;; \
+        arm64) artichokeArch='aarch64-unknown-linux-musl' ;; \
         *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
     esac; \
     if [ "$ARTICHOKE_NIGHTLY_VER" = "latest" ]; then \
-      RUSTFLAGS="-C link-arg=-s" cargo install --target "$targetArch" --git https://github.com/artichoke/artichoke --branch trunk --locked artichoke; \
+      RUSTFLAGS="-C link-arg=-s" cargo install --target "$artichokeArch" --git https://github.com/artichoke/artichoke --branch trunk --locked artichoke; \
     else \
-      RUSTFLAGS="-C link-arg=-s" cargo install --target "$targetArch" --git https://github.com/artichoke/artichoke --rev "$ARTICHOKE_NIGHTLY_VER" --locked artichoke; \
+      RUSTFLAGS="-C link-arg=-s" cargo install --target "$artichokeArch" --git https://github.com/artichoke/artichoke --rev "$ARTICHOKE_NIGHTLY_VER" --locked artichoke; \
     fi; \
     airb --version; \
     artichoke --version; \

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04 AS build
+FROM --platform=$BUILDPLATFORM ubuntu:20.04 AS build
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
@@ -62,6 +62,10 @@ RUN set -eux; \
     cargo install --version $BINDGEN_VERSION bindgen; \
     bindgen --version
 
+ARG TARGETPLATFORM
+ARG TARGETARCH
+ARG TARGETVARIANT
+
 # The `ARTICHOKE_NIGHTLY_VER` build arg allows building a specific revision of
 # Artichoke. The GitHub Actions workflow sets this to the latest trunk commit
 # SHA in the upstream Artichoke repository.
@@ -71,8 +75,7 @@ RUN set -eux; \
 ARG ARTICHOKE_NIGHTLY_VER=latest
 # Install artichoke
 RUN set -eux; \
-    dpkgArch="$(dpkg --print-architecture)"; \
-    case "${dpkgArch##*-}" in \
+    case "${TARGETARCH}" in \
         amd64) artichokeArch='x86_64-unknown-linux-musl' ;; \
         arm64) artichokeArch='aarch64-unknown-linux-musl' ;; \
         *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y --no
     clang \
     git \
     libclang-dev \
+    llvm \
     musl-tools \
     wget \
     && rm -rf /var/lib/apt/lists/*
@@ -43,9 +44,19 @@ RUN set -eux; \
     rustup target add x86_64-unknown-linux-musl; \
     rustup target add aarch64-unknown-linux-musl;
 
+# To get a cross compiler for aarch64-unknown-linux-musl, use clang and override
+# the `cc` crate's compiler detection, which defaults to `aarch64-linux-musl-gcc`.
+#
+# https://github.com/briansmith/ring/issues/1414#issuecomment-1055177218
+ENV CC_aarch64_unknown_linux_musl=clang
+ENV AR_aarch64_unknown_linux_musl=llvm-ar
+ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS="-Clink-self-contained=yes -Clinker=rust-lld"
+
 # Install bindgen
 ARG BINDGEN_VERSION=0.60.1
 RUN set -eux; \
+    rustup component add --target x86_64-unknown-linux-musl rustfmt; \
+    rustup component add --target aarch64-unknown-linux-musl rustfmt; \
     cargo install --version $BINDGEN_VERSION bindgen; \
     bindgen --version
 

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -59,7 +59,7 @@ ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 ARG BINDGEN_VERSION=0.60.1
 RUN set -eux; \
     rustup component add rustfmt; \
-    cargo install --version $BINDGEN_VERSION bindgen; \
+    cargo install --version $BINDGEN_VERSION --locked bindgen; \
     bindgen --version
 
 ARG TARGETPLATFORM

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -39,7 +39,7 @@ RUN set -eux; \
     cargo --version; \
     rustc --version;
 
-# Add multi-platform musl target support
+# Add multi-platform musl target support.
 RUN set -eux; \
     rustup target add x86_64-unknown-linux-musl; \
     rustup target add aarch64-unknown-linux-musl;
@@ -52,6 +52,9 @@ ENV CC_aarch64_unknown_linux_musl=clang
 ENV AR_aarch64_unknown_linux_musl=llvm-ar
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS="-Clink-self-contained=yes -Clinker=rust-lld"
 
+# This option tells Cargo to use the `git` binary instead of `libgit2` for git
+# operations, which is significantly faster.
+#
 # https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -40,7 +40,8 @@ RUN set -eux; \
 
 # Add libmusl support for Alpine
 RUN set -eux; \
-    rustup target add x86_64-unknown-linux-musl
+    rustup target add x86_64-unknown-linux-musl; \
+    rustup target add aarch64-unknown-linux-musl;
 
 # Install bindgen
 ARG BINDGEN_VERSION=0.60.1

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -55,8 +55,7 @@ ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS="-Clink-self-contained=yes
 # Install bindgen
 ARG BINDGEN_VERSION=0.60.1
 RUN set -eux; \
-    rustup component add --target x86_64-unknown-linux-musl rustfmt; \
-    rustup component add --target aarch64-unknown-linux-musl rustfmt; \
+    rustup component add rustfmt; \
     cargo install --version $BINDGEN_VERSION bindgen; \
     bindgen --version
 

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -64,9 +64,19 @@ RUN set -eux; \
         *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
     esac; \
     if [ "$ARTICHOKE_NIGHTLY_VER" = "latest" ]; then \
-      RUSTFLAGS="-C link-arg=-s" cargo install --target "$artichokeArch" --git https://github.com/artichoke/artichoke --branch trunk --locked artichoke; \
+      RUSTFLAGS="-C link-arg=-s" cargo install \
+        --target "$artichokeArch" \
+        --git https://github.com/artichoke/artichoke \
+        --branch trunk \
+        --locked \
+        artichoke; \
     else \
-      RUSTFLAGS="-C link-arg=-s" cargo install --target "$artichokeArch" --git https://github.com/artichoke/artichoke --rev "$ARTICHOKE_NIGHTLY_VER" --locked artichoke; \
+      RUSTFLAGS="-C link-arg=-s"  cargo install \
+        --target "$artichokeArch" \
+        --git https://github.com/artichoke/artichoke \
+        --rev "$ARTICHOKE_NIGHTLY_VER" \
+        --locked \
+        artichoke; \
     fi; \
     airb --version; \
     artichoke --version; \

--- a/debian/bullseye/slim/Dockerfile
+++ b/debian/bullseye/slim/Dockerfile
@@ -54,7 +54,7 @@ ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 ARG BINDGEN_VERSION=0.60.1
 RUN set -eux; \
     rustup component add rustfmt; \
-    cargo install --version $BINDGEN_VERSION bindgen; \
+    cargo install --version $BINDGEN_VERSION --locked bindgen; \
     bindgen --version
 
 ARG TARGETPLATFORM

--- a/debian/bullseye/slim/Dockerfile
+++ b/debian/bullseye/slim/Dockerfile
@@ -40,6 +40,7 @@ RUN set -eux; \
 # Install bindgen
 ARG BINDGEN_VERSION=0.60.1
 RUN set -eux; \
+    rustup component add rustfmt; \
     cargo install --version $BINDGEN_VERSION bindgen; \
     bindgen --version
 

--- a/debian/bullseye/slim/Dockerfile
+++ b/debian/bullseye/slim/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc-aarch64-linux-gnu \
     gcc-x86-64-linux-gnu \
     git \
+    libc6-dev-arm64-cross \
     libclang-dev \
     wget \
     && rm -rf /var/lib/apt/lists/*

--- a/debian/bullseye/slim/Dockerfile
+++ b/debian/bullseye/slim/Dockerfile
@@ -73,7 +73,7 @@ RUN set -eux; \
     case "${TARGETARCH}" in \
         amd64) artichokeArch='x86_64-unknown-linux-gnu' ;; \
         arm64) artichokeArch='aarch64-unknown-linux-gnu'; export BINDGEN_EXTRA_CLANG_ARGS='--sysroot=/usr/aarch64-linux-gnu' ;; \
-        *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
+        *) echo >&2 "unsupported architecture: ${TARGETARCH}"; exit 1 ;; \
     esac; \
     if [ "$ARTICHOKE_NIGHTLY_VER" = "latest" ]; then \
       cargo install \

--- a/debian/bullseye/slim/Dockerfile
+++ b/debian/bullseye/slim/Dockerfile
@@ -1,10 +1,12 @@
-FROM debian:bullseye-slim AS build
+FROM --platform=$BUILDPLATFORM debian:bullseye-slim AS build
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    binutils-aarch64-linux-gnu \
     ca-certificates \
     clang \
+    gcc-aarch64-linux-gnu \
     git \
     libclang-dev \
     wget \
@@ -37,6 +39,8 @@ RUN set -eux; \
     cargo --version; \
     rustc --version;
 
+ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+
 # https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 
@@ -47,6 +51,10 @@ RUN set -eux; \
     cargo install --version $BINDGEN_VERSION bindgen; \
     bindgen --version
 
+ARG TARGETPLATFORM
+ARG TARGETARCH
+ARG TARGETVARIANT
+
 # The `ARTICHOKE_NIGHTLY_VER` build arg allows building a specific revision of
 # Artichoke. The GitHub Actions workflow sets this to the latest trunk commit
 # SHA in the upstream Artichoke repository.
@@ -56,10 +64,9 @@ RUN set -eux; \
 ARG ARTICHOKE_NIGHTLY_VER=latest
 # Install artichoke
 RUN set -eux; \
-    dpkgArch="$(dpkg --print-architecture)"; \
-    case "${dpkgArch##*-}" in \
+    case "${TARGETARCH}" in \
         amd64) artichokeArch='x86_64-unknown-linux-gnu' ;; \
-        arm64) artichokeArch='aarch64-unknown-linux-gnu' ;; \
+        arm64) artichokeArch='aarch64-unknown-linux-gnu'; export BINDGEN_EXTRA_CLANG_ARGS='--sysroot=/usr/aarch64-linux-gnu' ;; \
         *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
     esac; \
     if [ "$ARTICHOKE_NIGHTLY_VER" = "latest" ]; then \

--- a/debian/bullseye/slim/Dockerfile
+++ b/debian/bullseye/slim/Dockerfile
@@ -59,14 +59,14 @@ RUN set -eux; \
         *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
     esac; \
     if [ "$ARTICHOKE_NIGHTLY_VER" = "latest" ]; then \
-      RUSTFLAGS="-C link-arg=-s" cargo install \
+      cargo install \
         --target "$artichokeArch" \
         --git https://github.com/artichoke/artichoke \
         --branch trunk \
         --locked \
         artichoke; \
     else \
-      RUSTFLAGS="-C link-arg=-s"  cargo install \
+      cargo install \
         --target "$artichokeArch" \
         --git https://github.com/artichoke/artichoke \
         --rev "$ARTICHOKE_NIGHTLY_VER" \

--- a/debian/bullseye/slim/Dockerfile
+++ b/debian/bullseye/slim/Dockerfile
@@ -37,6 +37,9 @@ RUN set -eux; \
     cargo --version; \
     rustc --version;
 
+# https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli
+ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
+
 # Install bindgen
 ARG BINDGEN_VERSION=0.60.1
 RUN set -eux; \

--- a/debian/bullseye/slim/Dockerfile
+++ b/debian/bullseye/slim/Dockerfile
@@ -90,8 +90,6 @@ RUN set -eux; \
         --locked \
         artichoke; \
     fi; \
-    airb --version; \
-    artichoke --version; \
     mkdir /target; \
     touch /target/THIRDPARTY;
 

--- a/debian/bullseye/slim/Dockerfile
+++ b/debian/bullseye/slim/Dockerfile
@@ -4,9 +4,11 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     binutils-aarch64-linux-gnu \
+    binutils-x86-64-linux-gnu \
     ca-certificates \
     clang \
     gcc-aarch64-linux-gnu \
+    gcc-x86-64-linux-gnu \
     git \
     libclang-dev \
     wget \
@@ -39,6 +41,10 @@ RUN set -eux; \
     cargo --version; \
     rustc --version;
 
+# Add multi-platform GNU target support
+RUN set -eux; \
+    rustup target add x86_64-unknown-linux-gnu; \
+    rustup target add aarch64-unknown-linux-gnu;
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
 
 # https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli

--- a/debian/bullseye/slim/Dockerfile
+++ b/debian/bullseye/slim/Dockerfile
@@ -59,9 +59,19 @@ RUN set -eux; \
         *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
     esac; \
     if [ "$ARTICHOKE_NIGHTLY_VER" = "latest" ]; then \
-      RUSTFLAGS="-C link-arg=-s" cargo install --target "$artichokeArch" --git https://github.com/artichoke/artichoke --branch trunk --locked artichoke; \
+      RUSTFLAGS="-C link-arg=-s" cargo install \
+        --target "$artichokeArch" \
+        --git https://github.com/artichoke/artichoke \
+        --branch trunk \
+        --locked \
+        artichoke; \
     else \
-      RUSTFLAGS="-C link-arg=-s" cargo install --target "$artichokeArch" --git https://github.com/artichoke/artichoke --rev "$ARTICHOKE_NIGHTLY_VER" --locked artichoke; \
+      RUSTFLAGS="-C link-arg=-s"  cargo install \
+        --target "$artichokeArch" \
+        --git https://github.com/artichoke/artichoke \
+        --rev "$ARTICHOKE_NIGHTLY_VER" \
+        --locked \
+        artichoke; \
     fi; \
     airb --version; \
     artichoke --version; \

--- a/debian/bullseye/slim/Dockerfile
+++ b/debian/bullseye/slim/Dockerfile
@@ -42,12 +42,20 @@ RUN set -eux; \
     cargo --version; \
     rustc --version;
 
-# Add multi-platform GNU target support
+# Add multi-platform GNU target support.
 RUN set -eux; \
     rustup target add x86_64-unknown-linux-gnu; \
     rustup target add aarch64-unknown-linux-gnu;
+
+# Cargo does not set the correct linker by default when acting as a cross
+# compiler. Tell cargo to use the aarch64 GCC toolchain's linker.
+#
+# https://github.com/rust-lang/rust/issues/28924
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
 
+# This option tells Cargo to use the `git` binary instead of `libgit2` for git
+# operations, which is significantly faster.
+#
 # https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 

--- a/debian/bullseye/slim/Dockerfile
+++ b/debian/bullseye/slim/Dockerfile
@@ -52,10 +52,16 @@ RUN set -eux; \
 ARG ARTICHOKE_NIGHTLY_VER=latest
 # Install artichoke
 RUN set -eux; \
+    dpkgArch="$(dpkg --print-architecture)"; \
+    case "${dpkgArch##*-}" in \
+        amd64) artichokeArch='x86_64-unknown-linux-gnu' ;; \
+        arm64) artichokeArch='aarch64-unknown-linux-gnu' ;; \
+        *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
+    esac; \
     if [ "$ARTICHOKE_NIGHTLY_VER" = "latest" ]; then \
-      RUSTFLAGS="-C link-arg=-s" cargo install --git https://github.com/artichoke/artichoke --branch trunk --locked artichoke; \
+      RUSTFLAGS="-C link-arg=-s" cargo install --target "$artichokeArch" --git https://github.com/artichoke/artichoke --branch trunk --locked artichoke; \
     else \
-      RUSTFLAGS="-C link-arg=-s" cargo install --git https://github.com/artichoke/artichoke --rev "$ARTICHOKE_NIGHTLY_VER" --locked artichoke; \
+      RUSTFLAGS="-C link-arg=-s" cargo install --target "$artichokeArch" --git https://github.com/artichoke/artichoke --rev "$ARTICHOKE_NIGHTLY_VER" --locked artichoke; \
     fi; \
     airb --version; \
     artichoke --version; \

--- a/ubuntu/focal/Dockerfile
+++ b/ubuntu/focal/Dockerfile
@@ -1,10 +1,12 @@
-FROM ubuntu:20.04 AS build
+FROM --platform=$BUILDPLATFORM ubuntu:20.04 AS build
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    binutils-aarch64-linux-gnu \
     ca-certificates \
     clang \
+    gcc-aarch64-linux-gnu \
     git \
     libclang-dev \
     wget \
@@ -37,6 +39,8 @@ RUN set -eux; \
     cargo --version; \
     rustc --version;
 
+ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+
 # https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 
@@ -47,6 +51,10 @@ RUN set -eux; \
     cargo install --version $BINDGEN_VERSION bindgen; \
     bindgen --version
 
+ARG TARGETPLATFORM
+ARG TARGETARCH
+ARG TARGETVARIANT
+
 # The `ARTICHOKE_NIGHTLY_VER` build arg allows building a specific revision of
 # Artichoke. The GitHub Actions workflow sets this to the latest trunk commit
 # SHA in the upstream Artichoke repository.
@@ -56,10 +64,9 @@ RUN set -eux; \
 ARG ARTICHOKE_NIGHTLY_VER=latest
 # Install artichoke
 RUN set -eux; \
-    dpkgArch="$(dpkg --print-architecture)"; \
-    case "${dpkgArch##*-}" in \
+    case "${TARGETARCH}" in \
         amd64) artichokeArch='x86_64-unknown-linux-gnu' ;; \
-        arm64) artichokeArch='aarch64-unknown-linux-gnu' ;; \
+        arm64) artichokeArch='aarch64-unknown-linux-gnu'; export BINDGEN_EXTRA_CLANG_ARGS='--sysroot=/usr/aarch64-linux-gnu' ;; \
         *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
     esac; \
     if [ "$ARTICHOKE_NIGHTLY_VER" = "latest" ]; then \

--- a/ubuntu/focal/Dockerfile
+++ b/ubuntu/focal/Dockerfile
@@ -54,7 +54,7 @@ ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 ARG BINDGEN_VERSION=0.60.1
 RUN set -eux; \
     rustup component add rustfmt; \
-    cargo install --version $BINDGEN_VERSION bindgen; \
+    cargo install --version $BINDGEN_VERSION --locked bindgen; \
     bindgen --version
 
 ARG TARGETPLATFORM

--- a/ubuntu/focal/Dockerfile
+++ b/ubuntu/focal/Dockerfile
@@ -16,6 +16,8 @@ RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y --no
     && rm -rf /var/lib/apt/lists/*
 
 # Rust setup
+#
+# https://github.com/rust-lang/docker-rust/blob/10f1b7cab43bde8b4d6299aa4d91a895a0e5388d/1.64.0/bullseye/slim/Dockerfile#L3-L37
 ARG RUST_VERSION=1.64.0
 
 ENV RUSTUP_HOME=/usr/local/rustup \
@@ -42,12 +44,20 @@ RUN set -eux; \
     cargo --version; \
     rustc --version;
 
-# Add multi-platform GNU target support
+# Add multi-platform GNU target support.
 RUN set -eux; \
     rustup target add x86_64-unknown-linux-gnu; \
     rustup target add aarch64-unknown-linux-gnu;
+
+# Cargo does not set the correct linker by default when acting as a cross
+# compiler. Tell cargo to use the aarch64 GCC toolchain's linker.
+#
+# https://github.com/rust-lang/rust/issues/28924
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
 
+# This option tells Cargo to use the `git` binary instead of `libgit2` for git
+# operations, which is significantly faster.
+#
 # https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 

--- a/ubuntu/focal/Dockerfile
+++ b/ubuntu/focal/Dockerfile
@@ -40,6 +40,7 @@ RUN set -eux; \
 # Install bindgen
 ARG BINDGEN_VERSION=0.60.1
 RUN set -eux; \
+    rustup component add rustfmt; \
     cargo install --version $BINDGEN_VERSION bindgen; \
     bindgen --version
 

--- a/ubuntu/focal/Dockerfile
+++ b/ubuntu/focal/Dockerfile
@@ -73,7 +73,7 @@ RUN set -eux; \
     case "${TARGETARCH}" in \
         amd64) artichokeArch='x86_64-unknown-linux-gnu' ;; \
         arm64) artichokeArch='aarch64-unknown-linux-gnu'; export BINDGEN_EXTRA_CLANG_ARGS='--sysroot=/usr/aarch64-linux-gnu' ;; \
-        *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
+        *) echo >&2 "unsupported architecture: ${TARGETARCH}"; exit 1 ;; \
     esac; \
     if [ "$ARTICHOKE_NIGHTLY_VER" = "latest" ]; then \
       cargo install \

--- a/ubuntu/focal/Dockerfile
+++ b/ubuntu/focal/Dockerfile
@@ -4,9 +4,11 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     binutils-aarch64-linux-gnu \
+    binutils-x86-64-linux-gnu \
     ca-certificates \
     clang \
     gcc-aarch64-linux-gnu \
+    gcc-x86-64-linux-gnu \
     git \
     libclang-dev \
     wget \
@@ -39,6 +41,10 @@ RUN set -eux; \
     cargo --version; \
     rustc --version;
 
+# Add multi-platform GNU target support
+RUN set -eux; \
+    rustup target add x86_64-unknown-linux-gnu; \
+    rustup target add aarch64-unknown-linux-gnu;
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
 
 # https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli

--- a/ubuntu/focal/Dockerfile
+++ b/ubuntu/focal/Dockerfile
@@ -59,14 +59,14 @@ RUN set -eux; \
         *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
     esac; \
     if [ "$ARTICHOKE_NIGHTLY_VER" = "latest" ]; then \
-      RUSTFLAGS="-C link-arg=-s" cargo install \
+      cargo install \
         --target "$artichokeArch" \
         --git https://github.com/artichoke/artichoke \
         --branch trunk \
         --locked \
         artichoke; \
     else \
-      RUSTFLAGS="-C link-arg=-s"  cargo install \
+      cargo install \
         --target "$artichokeArch" \
         --git https://github.com/artichoke/artichoke \
         --rev "$ARTICHOKE_NIGHTLY_VER" \

--- a/ubuntu/focal/Dockerfile
+++ b/ubuntu/focal/Dockerfile
@@ -37,6 +37,9 @@ RUN set -eux; \
     cargo --version; \
     rustc --version;
 
+# https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli
+ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
+
 # Install bindgen
 ARG BINDGEN_VERSION=0.60.1
 RUN set -eux; \

--- a/ubuntu/focal/Dockerfile
+++ b/ubuntu/focal/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y --no
     gcc-aarch64-linux-gnu \
     gcc-x86-64-linux-gnu \
     git \
+    libc6-dev-arm64-cross \
     libclang-dev \
     wget \
     && rm -rf /var/lib/apt/lists/*

--- a/ubuntu/focal/Dockerfile
+++ b/ubuntu/focal/Dockerfile
@@ -90,8 +90,6 @@ RUN set -eux; \
         --locked \
         artichoke; \
     fi; \
-    airb --version; \
-    artichoke --version; \
     mkdir /target; \
     touch /target/THIRDPARTY;
 

--- a/ubuntu/focal/Dockerfile
+++ b/ubuntu/focal/Dockerfile
@@ -59,9 +59,19 @@ RUN set -eux; \
         *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
     esac; \
     if [ "$ARTICHOKE_NIGHTLY_VER" = "latest" ]; then \
-      RUSTFLAGS="-C link-arg=-s" cargo install --target "$artichokeArch" --git https://github.com/artichoke/artichoke --branch trunk --locked artichoke; \
+      RUSTFLAGS="-C link-arg=-s" cargo install \
+        --target "$artichokeArch" \
+        --git https://github.com/artichoke/artichoke \
+        --branch trunk \
+        --locked \
+        artichoke; \
     else \
-      RUSTFLAGS="-C link-arg=-s" cargo install --target "$artichokeArch" --git https://github.com/artichoke/artichoke --rev "$ARTICHOKE_NIGHTLY_VER" --locked artichoke; \
+      RUSTFLAGS="-C link-arg=-s"  cargo install \
+        --target "$artichokeArch" \
+        --git https://github.com/artichoke/artichoke \
+        --rev "$ARTICHOKE_NIGHTLY_VER" \
+        --locked \
+        artichoke; \
     fi; \
     airb --version; \
     artichoke --version; \

--- a/ubuntu/focal/Dockerfile
+++ b/ubuntu/focal/Dockerfile
@@ -52,10 +52,16 @@ RUN set -eux; \
 ARG ARTICHOKE_NIGHTLY_VER=latest
 # Install artichoke
 RUN set -eux; \
+    dpkgArch="$(dpkg --print-architecture)"; \
+    case "${dpkgArch##*-}" in \
+        amd64) artichokeArch='x86_64-unknown-linux-gnu' ;; \
+        arm64) artichokeArch='aarch64-unknown-linux-gnu' ;; \
+        *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
+    esac; \
     if [ "$ARTICHOKE_NIGHTLY_VER" = "latest" ]; then \
-      RUSTFLAGS="-C link-arg=-s" cargo install --git https://github.com/artichoke/artichoke --branch trunk --locked artichoke; \
+      RUSTFLAGS="-C link-arg=-s" cargo install --target "$artichokeArch" --git https://github.com/artichoke/artichoke --branch trunk --locked artichoke; \
     else \
-      RUSTFLAGS="-C link-arg=-s" cargo install --git https://github.com/artichoke/artichoke --rev "$ARTICHOKE_NIGHTLY_VER" --locked artichoke; \
+      RUSTFLAGS="-C link-arg=-s" cargo install --target "$artichokeArch" --git https://github.com/artichoke/artichoke --rev "$ARTICHOKE_NIGHTLY_VER" --locked artichoke; \
     fi; \
     airb --version; \
     artichoke --version; \


### PR DESCRIPTION
Followed the docs here:

- https://github.com/docker/build-push-action/blob/83a00fb5e6d489daf5aaa5bad5efc9cd267d3dc8/docs/advanced/multi-platform.md
- https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/

These multi-arch builds leverage the host platform for the build stage in the multi-stage `Dockerfile`. Only tested on x86_64 hosts.

Fixes https://github.com/artichoke/docker-artichoke-nightly/issues/123.

This PR skips adding multi-arch images for Alpine, since I ran into the same problems with bindgen and a cross musl libc I did in https://github.com/artichoke/nightly/pull/96.