### PR TITLE
Update generate_third_party GitHub Action to 1.2.0

### DIFF
--- a/.github/workflows/docker-nightly.yaml
+++ b/.github/workflows/docker-nightly.yaml
@@ -62,7 +62,7 @@ jobs:
           echo "::set-output name=version::$(cat rust-toolchain)"
 
       - name: Generate THIRDPARTY license listing
-        uses: artichoke/generate_third_party@v1.1.0
+        uses: artichoke/generate_third_party@v1.2.0
         with:
           artichoke_ref: ${{ steps.latest.outputs.commit }}
           target_triple: ${{ matrix.target_triple }}


### PR DESCRIPTION
Pull in the fix for clarify checksum mismatch on windows:

- https://github.com/artichoke/generate_third_party/pull/36

Keep parity with nightly builder:

- https://github.com/artichoke/nightly/pull/107