### PR TITLE
Upgrade Rust toolchain to 1.66.0

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -55,7 +55,7 @@ namespace :release do
   end
 end
 
-RUST_VERSION = '1.65.0'
+RUST_VERSION = '1.66.0'
 
 namespace :toolchain do
   desc 'Sync Rust toolchain to all sources'

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y --no
     && rm -rf /var/lib/apt/lists/*
 
 # Rust setup
-ARG RUST_VERSION=1.65.0
+ARG RUST_VERSION=1.66.0
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \

--- a/debian/bullseye/slim/Dockerfile
+++ b/debian/bullseye/slim/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Rust setup
-ARG RUST_VERSION=1.65.0
+ARG RUST_VERSION=1.66.0
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \

--- a/ubuntu/focal/Dockerfile
+++ b/ubuntu/focal/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y --no
 # Rust setup
 #
 # https://github.com/rust-lang/docker-rust/blob/10f1b7cab43bde8b4d6299aa4d91a895a0e5388d/1.64.0/bullseye/slim/Dockerfile#L3-L37
-ARG RUST_VERSION=1.65.0
+ARG RUST_VERSION=1.66.0
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \


### PR DESCRIPTION
The corresponding PR to upgrade Artichoke's Rust toolchain is:

- https://github.com/artichoke/artichoke/pull/2310