### PR TITLE
Stop tagging Docker images with artichoke/artichoke git SHA

### DIFF
--- a/.github/workflows/docker-nightly.yaml
+++ b/.github/workflows/docker-nightly.yaml
@@ -94,10 +94,8 @@ jobs:
           push: ${{ github.ref == 'refs/heads/trunk' }}
           tags: |
             artichokeruby/artichoke:latest
-            artichokeruby/artichoke:${{ steps.latest.outputs.commit }}
             artichokeruby/artichoke:${{ matrix.tag_bare }}-nightly
             artichokeruby/artichoke:${{ matrix.tag_version }}-nightly
-            artichokeruby/artichoke:${{ matrix.tag_bare }}-nightly-${{ steps.latest.outputs.commit }}
           build-args: |
             ARTICHOKE_NIGHTLY_VER=${{ steps.latest.outputs.commit }}
             RUST_VERSION=${{ steps.rust_toolchain.outputs.version }}
@@ -112,7 +110,6 @@ jobs:
           push: ${{ github.ref == 'refs/heads/trunk' }}
           tags: |
             artichokeruby/artichoke:latest
-            artichokeruby/artichoke:${{ steps.latest.outputs.commit }}
             artichokeruby/artichoke:ubuntu20.04-nightly
           build-args: |
             ARTICHOKE_NIGHTLY_VER=${{ steps.latest.outputs.commit }}


### PR DESCRIPTION
Stop tagging Docker images pushed to Docker Hub with the git SHA of the source commit from the artichoke/artichoke repository.

This data is already tracked in OCI image metadata and is not useful for pinning since the images in this repository are all nighlies.

This change removes the following image tag formats:

- `<git SHA>`
- `alpine-nightly-<git SHA>`
- `slim-nightly-<git SHA>`
- `ubuntu-nightly-<git SHA>`

This change will reduce the number of tags significantly and reduce the number of active blobs stored in the repository, which will be useful as the Artichoke organization shifts to a self-hosted registry.

See #141.