### PR TITLE
Ensure artichokeruby/artichoke:latest is always Ubuntu base image

### DIFF
--- a/.github/workflows/docker-nightly.yaml
+++ b/.github/workflows/docker-nightly.yaml
@@ -93,7 +93,6 @@ jobs:
           file: ${{ matrix.dockerfile }}
           push: ${{ github.ref == 'refs/heads/trunk' }}
           tags: |
-            artichokeruby/artichoke:latest
             artichokeruby/artichoke:${{ matrix.tag_bare }}-nightly
             artichokeruby/artichoke:${{ matrix.tag_version }}-nightly
           build-args: |


### PR DESCRIPTION
On a recent pull to try out docker scout, I noticed that the :latest tag was a Debian Bullseye base. It looks like all container builds get tagged as :latest by the build matrix, leaving the :latest tag subject to a race condition.

Remove this erroneous tag to ensure :latest always points to an Ubuntu image.