### PR TITLE
Upgrade `artichoke/generate_third_party` to v1.5.0

### DIFF
--- a/.github/workflows/docker-nightly.yaml
+++ b/.github/workflows/docker-nightly.yaml
@@ -65,7 +65,7 @@ jobs:
           echo "version=$(cat rust-toolchain)" >> $GITHUB_OUTPUT
 
       - name: Generate THIRDPARTY license listing
-        uses: artichoke/generate_third_party@v1.3.0
+        uses: artichoke/generate_third_party@v1.5.0
         with:
           artichoke_ref: ${{ steps.latest.outputs.commit }}
           target_triple: ${{ matrix.target_triple }}

--- a/debian/bullseye/slim/Dockerfile
+++ b/debian/bullseye/slim/Dockerfile
@@ -68,6 +68,8 @@ ARG TARGETPLATFORM
 ARG TARGETARCH
 ARG TARGETVARIANT
 
+ENV BINDGEN_EXTRA_CLANG_ARGS_aarch64-unknown-linux-gnu=--sysroot=/usr/aarch64-linux-gnu
+
 # The `ARTICHOKE_NIGHTLY_VER` build arg allows building a specific revision of
 # Artichoke. The GitHub Actions workflow sets this to the latest trunk commit
 # SHA in the upstream Artichoke repository.

--- a/ubuntu/jammy/Dockerfile
+++ b/ubuntu/jammy/Dockerfile
@@ -70,6 +70,8 @@ ARG TARGETPLATFORM
 ARG TARGETARCH
 ARG TARGETVARIANT
 
+ENV BINDGEN_EXTRA_CLANG_ARGS_aarch64-unknown-linux-gnu=--sysroot=/usr/aarch64-linux-gnu
+
 # The `ARTICHOKE_NIGHTLY_VER` build arg allows building a specific revision of
 # Artichoke. The GitHub Actions workflow sets this to the latest trunk commit
 # SHA in the upstream Artichoke repository.


### PR DESCRIPTION
Includes fixes to support new bindgen deps, updates embedded mruby license for v3.2.0.

See:

- https://github.com/artichoke/generate_third_party/pull/85
- https://github.com/artichoke/generate_third_party/pull/86
- https://github.com/artichoke/artichoke/pull/2515

Related PR in nightly builder is:

- https://github.com/artichoke/nightly/pull/154