### PR TITLE
Upgrade Debian Slim image to Debian 12 Bookworm

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
           - build: alpine
             dockerfile: alpine/Dockerfile
           - build: debian
-            dockerfile: debian/bullseye/slim/Dockerfile
+            dockerfile: debian/bookworm/slim/Dockerfile
           - build: ubuntu
             dockerfile: ubuntu/jammy/Dockerfile
 
@@ -58,7 +58,7 @@ jobs:
         uses: docker://hadolint/hadolint:latest
         with:
           entrypoint: /bin/hadolint
-          args: --config /github/workspace/.hadolint.yaml /github/workspace/debian/bullseye/slim/Dockerfile
+          args: --config /github/workspace/.hadolint.yaml /github/workspace/debian/bookworm/slim/Dockerfile
 
       - name: Lint Alpine Dockerfile
         uses: docker://hadolint/hadolint:latest

--- a/.github/workflows/docker-nightly.yaml
+++ b/.github/workflows/docker-nightly.yaml
@@ -30,10 +30,10 @@ jobs:
             tag_version: alpine3
           - build: debian
             target_triple: x86_64-unknown-linux-gnu
-            dockerfile: debian/bullseye/slim/Dockerfile
+            dockerfile: debian/bookworm/slim/Dockerfile
             docker_target_platforms: linux/amd64,linux/arm64
             tag_bare: slim
-            tag_version: slim-bullseye
+            tag_version: slim-bookworm
           - build: ubuntu
             target_triple: x86_64-unknown-linux-gnu
             dockerfile: ubuntu/jammy/Dockerfile

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Currently supported docker platforms are:
   `latest`, `ubuntu-nightly`, `ubuntu-jammy-nightly`, and `ubuntu22.04-nightly`.
   Ubuntu images are multi-arch images with `linux/amd64` and `linux/arm64`
   support.
-- `debian-slim` - Debian 11 (Bullseye) slim image, tagged `slim-nightly` and
-  `slim-bullseye-nightly`. Debian images are multi-arch images with
+- `debian-slim` - Debian 12 (Bookworm) slim image, tagged `slim-nightly` and
+  `slim-bookworm-nightly`. Debian images are multi-arch images with
   `linux/amd64` and `linux/arm64` support.
 - `alpine` - Alpine 3 image, tagged with `alpine-nightly` and `alpine3-nightly`.
   Alpine images only have `linux/amd64` architecture support.

--- a/debian/bookworm/slim/Dockerfile
+++ b/debian/bookworm/slim/Dockerfile
@@ -5,7 +5,7 @@ FROM --platform=$BUILDPLATFORM debian:bookworm-slim AS build
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install necessary build dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     binutils-aarch64-linux-gnu \
     binutils-x86-64-linux-gnu \
     ca-certificates \

--- a/debian/bookworm/slim/Dockerfile
+++ b/debian/bookworm/slim/Dockerfile
@@ -137,8 +137,8 @@ COPY --from=build /usr/local/cargo/bin/airb /opt/artichoke/bin/airb
 COPY --from=build /target/THIRDPARTY /opt/artichoke/THIRDPARTY
 
 # Use a non-root user
-RUN groupadd --system --gid 1888 artichoke && \
-    useradd --no-log-init --system --gid artichoke --uid 1888 artichoke
+RUN groupadd --gid 1888 artichoke && \
+    useradd --no-log-init --gid artichoke --uid 1888 artichoke
 USER artichoke
 
 ENV ARTICHOKE_BIN /opt/artichoke/bin

--- a/debian/bookworm/slim/Dockerfile
+++ b/debian/bookworm/slim/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM --platform=$BUILDPLATFORM debian:bullseye-slim AS build
+FROM --platform=$BUILDPLATFORM debian:bookworm-slim AS build
 
 # Set shell options
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -112,7 +112,7 @@ RUN set -eux; \
 COPY THIRDPART[Y] /target/THIRDPARTY
 
 # Runtime stage
-FROM debian:bullseye-slim AS runtime
+FROM debian:bookworm-slim AS runtime
 
 ARG ARTICHOKE_NIGHTLY_VERSION=latest
 ARG ARTICHOKE_NIGHTLY_REVISION=latest
@@ -130,7 +130,7 @@ LABEL org.opencontainers.image.licenses="MIT"
 LABEL org.opencontainers.image.ref.name="slim-nightly"
 LABEL org.opencontainers.image.title="Artichoke Ruby nightly"
 LABEL org.opencontainers.image.description="Distribution of artichoke CLI and airb REPL from Artichoke Ruby"
-LABEL org.opencontainers.image.base.name="docker.io/library/debian:bullseye-slim"
+LABEL org.opencontainers.image.base.name="docker.io/library/debian:bookworm-slim"
 
 COPY --from=build /usr/local/cargo/bin/artichoke /opt/artichoke/bin/artichoke
 COPY --from=build /usr/local/cargo/bin/airb /opt/artichoke/bin/airb

--- a/doc/docker-hub-image-readme.md
+++ b/doc/docker-hub-image-readme.md
@@ -40,8 +40,8 @@ Currently supported docker platforms are:
   `latest`, `ubuntu-nightly`, `ubuntu-jammy-nightly`, and `ubuntu22.04-nightly`.
   Ubuntu images are multi-arch images with `linux/amd64` and `linux/arm64`
   support.
-- `debian-slim` - Debian 11 (Bullseye) slim image, tagged `slim-nightly` and
-  `slim-bullseye-nightly`. Debian images are multi-arch images with
+- `debian-slim` - Debian 12 (Bookworm) slim image, tagged `slim-nightly` and
+  `slim-bookworm-nightly`. Debian images are multi-arch images with
   `linux/amd64` and `linux/arm64` support.
 - `alpine` - Alpine 3 image, tagged with `alpine-nightly` and `alpine3-nightly`.
 

--- a/ubuntu/jammy/Dockerfile
+++ b/ubuntu/jammy/Dockerfile
@@ -139,8 +139,8 @@ COPY --from=build /usr/local/cargo/bin/airb /opt/artichoke/bin/airb
 COPY --from=build /target/THIRDPARTY /opt/artichoke/THIRDPARTY
 
 # Use a non-root user
-RUN groupadd --system --gid 1888 artichoke && \
-    useradd --no-log-init --system --gid artichoke --uid 1888 artichoke
+RUN groupadd --gid 1888 artichoke && \
+    useradd --no-log-init --gid artichoke --uid 1888 artichoke
 USER artichoke
 
 ENV ARTICHOKE_BIN /opt/artichoke/bin


### PR DESCRIPTION
Fixes https://github.com/artichoke/docker-artichoke-nightly/issues/159.

Additional changes were made to dockerfiles to silence build log warnings.