### PR TITLE
Automate the gathering and publishing of new toolchain versions

### DIFF
--- a/.github/workflows/toolchain-version-check.yaml
+++ b/.github/workflows/toolchain-version-check.yaml
@@ -2,7 +2,7 @@
 name: Toolchain Version Check
 "on":
   schedule:
-    - cron: "0 0 * * *" # build nightly!
+    - cron: "0 5 * * 5" # 5am UTC Fridays
 
 jobs:
   check-toolchain-version:

--- a/.github/workflows/toolchain-version-check.yaml
+++ b/.github/workflows/toolchain-version-check.yaml
@@ -2,7 +2,7 @@
 name: Toolchain Version Check
 "on":
   schedule:
-    - cron: "0 5 * * 5" # 5am UTC Fridays
+    - cron: "0 5 * * 5" # 5am UTC Fridays. Rust toolchain versions merge Thursday afternoons.
 
 jobs:
   check-toolchain-version:

--- a/.github/workflows/toolchain-version-check.yaml
+++ b/.github/workflows/toolchain-version-check.yaml
@@ -56,13 +56,17 @@ jobs:
         uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 # v5.0.2
         if: ${{ steps.version_info.outputs.matches != 'true' }}
         with:
-          title: Update the rust toolchain
+          title: Update the rust toolchain from ${{ steps.version_info.outputs.current }} to ${{ steps.version_info.outputs.next }}
           body: |
             ⚠ This PR is automatically created via a Github Action. Ensure all changes are valid before merging.
 
-            Update the toolchain and sync to the latest available in rust-lang/rust
+            Update the toolchain and sync to the latest available in rust-lang/rust.
+
+            Current toolchain version: ${{ steps.version_info.outputs.current }}
+            Latest toolchain version: ${{ steps.version_info.outputs.next }}
 
             [Changelog](https://github.com/rust-lang/rust/blob/master/RELEASES.md)
+            [Commits](https://github.com/rust-lang/rust/compare/${{ steps.version_info.outputs.current}}...${{ steps.version_info.outputs.next }})
           commit-message: Sync the toolchain to the latest Rust upstream
           base: trunk
           branch: actions/update-toolchain-version

--- a/.github/workflows/toolchain-version-check.yaml
+++ b/.github/workflows/toolchain-version-check.yaml
@@ -44,7 +44,7 @@ jobs:
           bundle exec rake toolchain:sync
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38
+        uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 # v5.0.2
         if: ${{ steps.rust_version.outputs.version != fromJson(steps.latest_rust_release.outputs.data).tag_name }}
         with:
           title: Update the rust toolchain

--- a/.github/workflows/toolchain-version-check.yaml
+++ b/.github/workflows/toolchain-version-check.yaml
@@ -1,0 +1,63 @@
+---
+name: Toolchain Version Check
+"on":
+  schedule:
+    - cron: "0 0 * * *" # build nightly!
+
+jobs:
+  check-toolchain-version:
+    name: Nightly
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4.1.1
+
+      - name: Install Ruby toolchain
+        uses: ruby/setup-ruby@8575951200e472d5f2d95c625da0c7bec8217c42 # v1.161.0
+        with:
+          ruby-version: ".ruby-version"
+          bundler-cache: true
+
+      - name: Read existing rustc version
+        id: rust_version
+        run: |
+          bundle exec rake toolchain:version
+          echo "version=$(bundle exec rake toolchain:version)" >> "$GITHUB_OUTPUT"
+
+      - name: Check the latest rustc version
+        id: latest_rust_release
+        uses: octokit/request-action@v2.1.9
+        with:
+          route: GET /repos/{owner}/{repo}/releases/latest
+          owner: rust-lang
+          repo: rust
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update the toolchain version and run sync
+        if: ${{ steps.rust_version.outputs.version != fromJson(steps.latest_rust_release.outputs.data).tag_name }}
+        env:
+          NEXT_VERSION: ${{ fromJson(steps.latest_rust_release.outputs.data).tag_name }}
+        run: |
+          # Matches "RUST_VERSION = 'M.M.P'" and replaces with "RUST_VERSION = '$NEXT_VRSION'"
+          sed -iE "s/^\(RUST_VERSION\ =\ '\).*\('\)\$/\1$NEXT_VERSION\2/g" Rakefile
+          bundle exec rake toolchain:sync
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5.0.2
+        if: ${{ steps.rust_version.outputs.version != fromJson(steps.latest_rust_release.outputs.data).tag_name }}
+        with:
+          title: Update the rust toolchain
+          body: |
+            ⚠ This PR is automatically created via a Github Action. Ensure all changs are valid before merging.
+
+            Update the toolchain and sync to the latest available in rust-lang/rust
+
+            [Changelog](https://github.com/rust-lang/rust/blob/master/RELEASES.md)
+          commit-message: Sync the toolchain to the latest Rust upstream
+          base: trunk
+          branch: actions/update-toolchain-version
+          labels: |
+            A-deps
+          assignees: |
+            b-n

--- a/.github/workflows/toolchain-version-check.yaml
+++ b/.github/workflows/toolchain-version-check.yaml
@@ -60,7 +60,7 @@ jobs:
         uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 # v5.0.2
         if: ${{ steps.version_info.outputs.matches != 'true' }}
         with:
-          title: Update the rust toolchain from ${{ steps.version_info.outputs.current }} to ${{ steps.version_info.outputs.next }}
+          title: Update Rust toolchain from ${{ steps.version_info.outputs.current }} to ${{ steps.version_info.outputs.next }}
           body: |
             ⚠ This PR is automatically created via a Github Action. Ensure all changes are valid before merging.
 

--- a/.github/workflows/toolchain-version-check.yaml
+++ b/.github/workflows/toolchain-version-check.yaml
@@ -50,10 +50,11 @@ jobs:
       - name: Update the toolchain version and run sync
         if: ${{ steps.version_info.outputs.matches != 'true' }}
         env:
-          NEXT_VERSION: ${{ steps.version_info.outputs.next }}
+          CURRENT: ${{ steps.version_info.outputs.current }}
+          NEXT: ${{ steps.version_info.outputs.next }}
         run: |
-          # Matches "RUST_VERSION = 'M.M.P'" and replaces `M.M.P` with `$NEXT_VERSION`
-          sed -iE "s/^\(RUST_VERSION\ =\ '\).*\('\)\$/\1$NEXT_VERSION\2/g" Rakefile
+          # Matches `RUST_VERSION = '$CURRENT'` and replaces with `RUST_VERSION = '$NEXT'`
+          sed -iE "s/^RUST_VERSION = '$CURRENT'$/RUST_VERSION = '$NEXT'/g" Rakefile
           bundle exec rake toolchain:sync
 
       - name: Create Pull Request

--- a/.github/workflows/toolchain-version-check.yaml
+++ b/.github/workflows/toolchain-version-check.yaml
@@ -41,7 +41,11 @@ jobs:
         run: |
           echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
           echo "next=$NEXT" >> "$GITHUB_OUTPUT"
-          echo "matches=$(test \"$CURRENT\" = \"$NEXT\" && echo 'true' || echo 'false')" >> "$GITHUB_OUTPUT"
+          if [[ "$CURRENT" == "$NEXT" ]]; then
+            echo "matches=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "matches=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Update the toolchain version and run sync
         if: ${{ steps.version_info.outputs.matches != 'true' }}

--- a/.github/workflows/toolchain-version-check.yaml
+++ b/.github/workflows/toolchain-version-check.yaml
@@ -21,7 +21,6 @@ jobs:
       - name: Read existing rustc version
         id: rust_version
         run: |
-          bundle exec rake toolchain:version
           echo "version=$(bundle exec rake toolchain:version)" >> "$GITHUB_OUTPUT"
 
       - name: Check the latest rustc version

--- a/.github/workflows/toolchain-version-check.yaml
+++ b/.github/workflows/toolchain-version-check.yaml
@@ -62,7 +62,8 @@ jobs:
         with:
           title: Update Rust toolchain from ${{ steps.version_info.outputs.current }} to ${{ steps.version_info.outputs.next }}
           body: |
-            ⚠ This PR is automatically created via a Github Action. Ensure all changes are valid before merging.
+            > [!WARNING]
+            > This PR is automatically created via a Github Action. Ensure all changes are valid before merging.
 
             Update the toolchain and sync to the latest available in rust-lang/rust.
 

--- a/.github/workflows/toolchain-version-check.yaml
+++ b/.github/workflows/toolchain-version-check.yaml
@@ -6,7 +6,7 @@ name: Toolchain Version Check
 
 jobs:
   check-toolchain-version:
-    name: Nightly
+    name: Check toolchain version
     runs-on: ubuntu-latest
 
     steps:
@@ -26,7 +26,7 @@ jobs:
 
       - name: Check the latest rustc version
         id: latest_rust_release
-        uses: octokit/request-action@v2.1.9
+        uses: octokit/request-action@89697eb6635e52c6e1e5559f15b5c91ba5100cb0 # v2.1.9
         with:
           route: GET /repos/{owner}/{repo}/releases/latest
           owner: rust-lang
@@ -39,17 +39,17 @@ jobs:
         env:
           NEXT_VERSION: ${{ fromJson(steps.latest_rust_release.outputs.data).tag_name }}
         run: |
-          # Matches "RUST_VERSION = 'M.M.P'" and replaces with "RUST_VERSION = '$NEXT_VRSION'"
+          # Matches "RUST_VERSION = 'M.M.P'" and replaces `M.M.P` with `$NEXT_VERSION`
           sed -iE "s/^\(RUST_VERSION\ =\ '\).*\('\)\$/\1$NEXT_VERSION\2/g" Rakefile
           bundle exec rake toolchain:sync
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5.0.2
+        uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38
         if: ${{ steps.rust_version.outputs.version != fromJson(steps.latest_rust_release.outputs.data).tag_name }}
         with:
           title: Update the rust toolchain
           body: |
-            ⚠ This PR is automatically created via a Github Action. Ensure all changs are valid before merging.
+            ⚠ This PR is automatically created via a Github Action. Ensure all changes are valid before merging.
 
             Update the toolchain and sync to the latest available in rust-lang/rust
 
@@ -60,4 +60,4 @@ jobs:
           labels: |
             A-deps
           assignees: |
-            b-n
+            @artichoke/contributors

--- a/.github/workflows/toolchain-version-check.yaml
+++ b/.github/workflows/toolchain-version-check.yaml
@@ -33,10 +33,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Update the toolchain version and run sync
-        if: ${{ steps.rust_version.outputs.version != fromJson(steps.latest_rust_release.outputs.data).tag_name }}
+      - name: Extract rust version info
+        id: version_info
         env:
-          NEXT_VERSION: ${{ fromJson(steps.latest_rust_release.outputs.data).tag_name }}
+          CURRENT: ${{ steps.rust_version.outputs.version }}
+          NEXT: ${{ fromJson(steps.latest_rust_release.outputs.data).tag_name }}
+        run: |
+          echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
+          echo "next=$NEXT" >> "$GITHUB_OUTPUT"
+          echo "matches=$(test \"$CURRENT\" = \"$NEXT\" && echo 'true' || echo 'false')" >> "$GITHUB_OUTPUT"
+
+      - name: Update the toolchain version and run sync
+        if: ${{ steps.version_info.outputs.matches != 'true' }}
+        env:
+          NEXT_VERSION: ${{ steps.version_info.outputs.next }}
         run: |
           # Matches "RUST_VERSION = 'M.M.P'" and replaces `M.M.P` with `$NEXT_VERSION`
           sed -iE "s/^\(RUST_VERSION\ =\ '\).*\('\)\$/\1$NEXT_VERSION\2/g" Rakefile
@@ -44,7 +54,7 @@ jobs:
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 # v5.0.2
-        if: ${{ steps.rust_version.outputs.version != fromJson(steps.latest_rust_release.outputs.data).tag_name }}
+        if: ${{ steps.version_info.outputs.matches != 'true' }}
         with:
           title: Update the rust toolchain
           body: |

--- a/Rakefile
+++ b/Rakefile
@@ -84,4 +84,9 @@ namespace :toolchain do
       raise 'Failed to update some RUST_VERSION args' if failures.any?
     end
   end
+
+  desc 'Output the current toolchain version'
+  task :version do
+    puts RUST_VERSION
+  end
 end


### PR DESCRIPTION
An attempt at automatically updating the toolchain version.

In short what this PR does:

- Get the current RUST_VERSION from the Rakefile
  I originally though of using some grep/regex magic to get this value, but thought: "Ruby knows best what it's looking for".
- Get the latest release from rust-lang/rust (This is what github determines as "latest" - so there is some limitation there if patches for older versions are released)
- IF the values are different:
  - update the value with sed magic in the file (Makes me second guess my "ruby knows best" comment above) and runs `bundle exec rake toolchain:sync`
  - Create[/Update] a PR to merge.

I've had some success running this action with [act](https://github.com/peter-evans/create-pull-request/issues/633), however for some reason I'm getting a "Could not read from remote repository" when it tries to run `git remote prune origin` here: https://github.com/peter-evans/create-pull-request/blob/main/src/create-pull-request.ts#L138. (running with `act -s GITHUB_TOKEN="$(gh auth token)" -j check-toolchain-version`, have also tried a hardcoded PAT token, to no success).

I can confirm everything works up until the git pr/commit part of it, so that's all good. In theory the last PR part should "Just work", but it might be a wait and see on the next rust release. I fear having a dirty tree (only easy way to test this) is causing some issue somewhere.

Fixes: #192 