### PR TITLE
Fix Legacy key/value format with whitespace separator should not be used

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -139,8 +139,8 @@ RUN addgroup --system --gid 1888 artichoke && \
     adduser --system -G artichoke --uid 1888 artichoke
 USER artichoke
 
-ENV ARTICHOKE_BIN /opt/artichoke/bin
-ENV PATH $ARTICHOKE_BIN:$PATH
+ENV ARTICHOKE_BIN=/opt/artichoke/bin
+ENV PATH=$ARTICHOKE_BIN:$PATH
 
 # Set the entry point command for the container to the REPL
 CMD [ "airb" ]

--- a/debian/bookworm/slim/Dockerfile
+++ b/debian/bookworm/slim/Dockerfile
@@ -143,8 +143,8 @@ RUN groupadd --gid 1888 artichoke && \
     useradd --no-log-init --gid artichoke --uid 1888 artichoke
 USER artichoke
 
-ENV ARTICHOKE_BIN /opt/artichoke/bin
-ENV PATH $ARTICHOKE_BIN:$PATH
+ENV ARTICHOKE_BIN=/opt/artichoke/bin
+ENV PATH=$ARTICHOKE_BIN:$PATH
 
 # Set the entry point command for the container to the REPL
 CMD [ "airb" ]

--- a/ubuntu/noble/Dockerfile
+++ b/ubuntu/noble/Dockerfile
@@ -145,8 +145,8 @@ RUN groupadd --gid 1888 artichoke && \
     useradd --no-log-init --gid artichoke --uid 1888 artichoke
 USER artichoke
 
-ENV ARTICHOKE_BIN /opt/artichoke/bin
-ENV PATH $ARTICHOKE_BIN:$PATH
+ENV ARTICHOKE_BIN=/opt/artichoke/bin
+ENV PATH=$ARTICHOKE_BIN:$PATH
 
 # Set the entry point command for the container to the REPL
 CMD [ "airb" ]


### PR DESCRIPTION
A bunch of warnings in CI that I just noticed.

LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format
More info: https://docs.docker.com/go/dockerfile/rule/legacy-key-value-format/