### PR TITLE
Fix red squiggle in VSCode

### DIFF
--- a/.github/workflows/toolchain-version-check.yaml
+++ b/.github/workflows/toolchain-version-check.yaml
@@ -31,9 +31,7 @@ jobs:
         id: latest_rust_release
         uses: octokit/request-action@dad4362715b7fb2ddedf9772c8670824af564f0d # v2.4.0
         with:
-          route: GET /repos/{owner}/{repo}/releases/latest
-          owner: rust-lang
-          repo: rust
+          route: GET /repos/rust-lang/rust/releases/latest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
`octokit/request-action` only defines a `route` input but it also will slurp up all provided action inputs and interpolate them into the provided route.

Because `owner` and `repo` aren't declared inputs to the action, VSCode reports an error. Replace this with a hardcoded route to minimize the chance of bugs and security vulnerabilities.