### PR TITLE
Add missing permissions for create pull request action

### DIFF
--- a/.github/workflows/toolchain-version-check.yaml
+++ b/.github/workflows/toolchain-version-check.yaml
@@ -9,6 +9,9 @@ jobs:
   check-toolchain-version:
     name: Check toolchain version
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
The Rust toolchain update job has been broken since #245 in February, which means the Rust toolchain embedded in all of the Dockerfiles hasn't been updated since Rust 1.84.1.

Artichoke's `Cargo.toml` currently specifies Rust 1.85.0. This means that the nightly builds, which parse Artichoke's declared `rust-toolchain.toml` and inject the Rust version via a Docker arg continue to build successfully, but the bare CI job, which uses the toolchain declared in the Dockerfiles, does not.

Cargo fails with a pretty bad error message:

```
0.048 + cargo install --target x86_64-unknown-linux-musl --git https://github.com/artichoke/artichoke --branch trunk --bins --locked artichoke@0.1.0-pre.0
0.098     Updating git repository `https://github.com/artichoke/artichoke`
2.888 From https://github.com/artichoke/artichoke
2.888  * [new branch]          trunk      -> origin/trunk
6.654 error: could not find `artichoke` in https://github.com/artichoke/artichoke?branch=trunk with version `=0.1.0-pre.0`
```